### PR TITLE
Default values should be parsed, closes #7

### DIFF
--- a/src/props/Prop.js
+++ b/src/props/Prop.js
@@ -137,7 +137,8 @@ let Self = class Prop {
 					return this.defaultProp.get(element);
 				}
 				else {
-					return resolveValue(this.default, [element, element]);
+					value = resolveValue(this.default, [element, element]);
+					return this.parse?.(value) ?? value;
 				}
 			}
 		}


### PR DESCRIPTION
It attempts to fix #7 by invoking `parse()`, if present, on a prop's resolved default value.

At the same time, it fixes the https://github.com/color-js/elements/issues/39 issue with `<color-picker>` when `space` is not provided.