### PR TITLE
Fix typo in `parse` for Maps

### DIFF
--- a/src/props/types.js
+++ b/src/props/types.js
@@ -297,8 +297,10 @@ types.set(Map, {
 		else if (typeof value === "object") {
 			entries = Object.entries(value);
 		}
+		else {
+			entries = parseEntries(value, options);
+		}
 
-		entries = parseEntries(value, options);
 		return Array.isArray(entries) ? new Map(entries) : entries;
 	},
 


### PR DESCRIPTION
Added the `else` block when evaluating `entries`.