### PR TITLE
[Prop] Add tests for `reflect`

### DIFF
--- a/test/Prop.js
+++ b/test/Prop.js
@@ -187,6 +187,42 @@ export default {
 						},
 					],
 				},
+				{
+					name: "Reflections",
+					run (spec) {
+						let prop = new Prop("foo", spec);
+						return prop.reflect;
+					},
+					tests: [
+						{
+							name: "By default, props are reflected",
+							arg: {},
+							expect: true,
+						},
+						{
+							name: "Disable reflection",
+							arg: {
+								reflect: false,
+							},
+							expect: false,
+						},
+						{
+							name: "Computed props are not reflected by default",
+							arg: {
+								get () {},
+							},
+							expect: false,
+						},
+						{
+							name: "Reflected computed prop",
+							arg: {
+								get () {},
+								reflect: true,
+							},
+							expect: true,
+						},
+					],
+				},
 			],
 		},
 	],


### PR DESCRIPTION
Tests for more complex things, like `reflect: { from: "foo", to: false }` will become part of the tests for `fromAttribute` and `toAttribute` (in the following PR).