### PR TITLE
Rename: `firePropChangedEvent` → `firePropChangeEvent`

### DIFF
--- a/src/events/defineEvents.js
+++ b/src/events/defineEvents.js
@@ -118,7 +118,7 @@ export default function defineEvents (Class, events = Class.events) {
 				let value = this[propName];
 
 				if (value !== undefined) {
-					Class.props.firePropChangedEvent(this, eventName, {
+					Class.props.firePropChangeEvent(this, eventName, {
 						name: propName,
 						prop: Class.props.get(propName),
 					});

--- a/src/props/Props.js
+++ b/src/props/Props.js
@@ -123,7 +123,7 @@ export default class Props extends Map {
 		// Fire propchange event
 		let eventNames = [ "propchange", ...(prop.eventNames ?? []) ];
 		for (let eventName of eventNames) {
-			this.firePropChangedEvent(element, eventName, {
+			this.firePropChangeEvent(element, eventName, {
 				name: prop.name,
 				prop,
 				detail: change
@@ -131,7 +131,7 @@ export default class Props extends Map {
 		}
 	}
 
-	firePropChangedEvent (element, eventName, eventProps) {
+	firePropChangeEvent (element, eventName, eventProps) {
 		let event = new PropChangeEvent(eventName, eventProps);
 
 		if (element.isConnected) {


### PR DESCRIPTION
This method should have a name corresponding to the event it fires. Closes #25