### PR TITLE
[Props][Prop] Delay the `propchange` events for uninitialized props

### DIFF
--- a/src/props/Prop.js
+++ b/src/props/Prop.js
@@ -13,6 +13,8 @@ let Self = class Prop {
 	 */
 	props;
 
+	#initialized = false;
+
 	constructor (name, spec, props) {
 		if (spec instanceof Prop && name === spec.name) {
 			return spec;
@@ -119,6 +121,8 @@ let Self = class Prop {
 			// Is not set and its default is not another prop
 			this.changed(element, {source: "default", element});
 		}
+
+		this.#initialized = true;
 	}
 
 	// Define the necessary getters and setters
@@ -306,6 +310,10 @@ let Self = class Prop {
 
 		return this.dependencies.has(prop.name)
 		       || (this.defaultProp === prop && element.props[this.name] === undefined);
+	}
+
+	get initialized () {
+		return this.#initialized;
 	}
 };
 

--- a/src/props/Props.js
+++ b/src/props/Props.js
@@ -12,6 +12,8 @@ export default class Props extends Map {
 	 */
 	dependents = {};
 
+	#initialized = false;
+
 	/**
 	 *
 	 * @param {HTMLElement} Class The class to define props for
@@ -134,7 +136,7 @@ export default class Props extends Map {
 	firePropChangeEvent (element, eventName, eventProps) {
 		let event = new PropChangeEvent(eventName, eventProps);
 
-		if (element.isConnected) {
+		if (element.isConnected && this.#initialized) {
 			element.dispatchEvent?.(event);
 		}
 		else {
@@ -160,6 +162,8 @@ export default class Props extends Map {
 			prop.initializeFor(element);
 		}
 
+		this.#initialized = true;
+
 		// Dispatch any events that were queued
 		let queue = this.eventDispatchQueue.get(element);
 
@@ -170,6 +174,10 @@ export default class Props extends Map {
 
 			this.eventDispatchQueue.delete(element);
 		}
+	}
+
+	get initialized () {
+		return this.#initialized;
 	}
 
 	/**

--- a/src/props/Props.js
+++ b/src/props/Props.js
@@ -12,8 +12,6 @@ export default class Props extends Map {
 	 */
 	dependents = {};
 
-	#initialized = false;
-
 	/**
 	 *
 	 * @param {HTMLElement} Class The class to define props for
@@ -136,7 +134,7 @@ export default class Props extends Map {
 	firePropChangeEvent (element, eventName, eventProps) {
 		let event = new PropChangeEvent(eventName, eventProps);
 
-		if (element.isConnected && this.#initialized) {
+		if (element.isConnected && eventProps.prop.initialized) {
 			element.dispatchEvent?.(event);
 		}
 		else {
@@ -162,8 +160,6 @@ export default class Props extends Map {
 			prop.initializeFor(element);
 		}
 
-		this.#initialized = true;
-
 		// Dispatch any events that were queued
 		let queue = this.eventDispatchQueue.get(element);
 
@@ -174,10 +170,6 @@ export default class Props extends Map {
 
 			this.eventDispatchQueue.delete(element);
 		}
-	}
-
-	get initialized () {
-		return this.#initialized;
 	}
 
 	/**


### PR DESCRIPTION
This helps us solve the problem with props set programmatically before elements are fully initialized.