### PR TITLE
[Props] Take dependency graph into account when working with props

### DIFF
--- a/src/props/Props.js
+++ b/src/props/Props.js
@@ -1,5 +1,5 @@
 import {
-	sortObject,
+	sortMap,
 } from "./util.js";
 import Prop from "./Prop.js";
 import PropChangeEvent from "./PropChangeEvent.js";
@@ -7,10 +7,10 @@ import PropChangeEvent from "./PropChangeEvent.js";
 export default class Props extends Map {
 	/**
 	 * Dependency graph
-	 * @type {Object.<string, Set<string>>}
-	 * Key is the name of the prop, value is a set of prop names that depend on it
+	 * @type {Map.<string, Set<Prop>>}
+	 * Key is the name of the prop, value is a set of props that depend on it
 	 */
-	dependents = {};
+	dependents = new Map();
 
 	/**
 	 *
@@ -48,10 +48,10 @@ export default class Props extends Map {
 
 	updateDependents () {
 		// Rebuild dependency graph
-		let dependents = {};
+		let dependents = new Map();
 
 		for (let name of this.keys()) {
-			dependents[name] = new Set();
+			dependents.set(name, new Set());
 		}
 
 		let keyIndices = Object.fromEntries([...this.keys()].map((key, i) => [key, i]));
@@ -73,10 +73,10 @@ export default class Props extends Map {
 
 			for (let name of dependencies) {
 				// ${name} depends on ${prop.name}
-				dependents[name]?.add(prop);
+				dependents.get(name)?.add(prop);
 
 				// Dependent props should come after the prop they depend on
-				if (keyIndices[name] < keyIndices[prop.name]) {
+				if (keyIndices[name] > keyIndices[prop.name]) {
 					// Swap the order of the props
 					[keyIndices[name], keyIndices[prop.name]] = [keyIndices[prop.name], keyIndices[name]];
 					sort = true;
@@ -84,13 +84,39 @@ export default class Props extends Map {
 			}
 		}
 
-		if (sort) {
+		if (!sort) {
+			this.dependents = dependents;
+		}
+		else {
 			// Sort dependency graph using the new order in keyIndices
 			// TODO put props with no dependencies first
 			// TODO do we need a topological sort?
-			this.dependents = sortObject(dependents, ([a], [b]) => {
+			this.dependents = sortMap(dependents, ([a], [b]) => {
 				return keyIndices[a] - keyIndices[b];
 			});
+
+			// Reorder the props according to their order in the dependency graph
+			// so that every time we use this.values() or this.keys(), the result is in the correct order
+			for (let propName of this.dependents.keys()) {
+				let prop = this.get(propName);
+				this.delete(propName);
+				this.set(propName, prop);
+			}
+
+			// Reorder dependents of every prop according to the dependency graph built
+			for (let [name, dependents] of this.dependents.entries()) {
+				if (dependents.size < 2) {
+					// Nothing to reorder
+					continue;
+				}
+
+				let props = [...dependents]
+					.map(prop => [prop, keyIndices[prop.name]])
+					.sort((a, b) => a[1] - b[1])
+					.map(([prop, i]) => prop);
+
+				this.dependents.set(name, new Set(props));
+			}
 		}
 	}
 
@@ -112,7 +138,7 @@ export default class Props extends Map {
 
 	propChanged (element, prop, change) {
 		// Update all props that have this prop as a dependency
-		let dependents = this.dependents[prop.name] ?? new Set();
+		let dependents = this.dependents.get(prop.name) ?? new Set();
 
 		for (let dependent of dependents) {
 			if (dependent.dependsOn(prop, element)) {

--- a/src/props/util.js
+++ b/src/props/util.js
@@ -14,15 +14,20 @@ export function inferDependencies (fn) {
 }
 
 /**
- * Sort an object literal based on an arbitrary comparison function.
- * @param {object} obj - The object to sort
+ * Sort a map based on an arbitrary comparison function.
+ * @param {Map} map - The map to sort
  * @param {Function} fn - Comparison function
- * @returns {object} New object with the entries sorted
+ * @returns {Map} New map with the entries sorted
  */
-export function sortObject (obj, fn) {
-	if (!obj) {
-		return obj;
+export function sortMap (map, fn) {
+	if (!map) {
+		return map;
 	}
 
-	return Object.fromEntries(Object.entries(obj).sort(fn));
+	let ret = new Map();
+	for (let [key, value] of [...map.entries()].sort(fn)) {
+		ret.set(key, value);
+	}
+
+	return ret;
 }

--- a/src/props/util.js
+++ b/src/props/util.js
@@ -14,20 +14,15 @@ export function inferDependencies (fn) {
 }
 
 /**
- * Sort a map based on an arbitrary comparison function.
- * @param {Map} map - The map to sort
+ * Sort an object literal based on an arbitrary comparison function.
+ * @param {object} obj - The object to sort
  * @param {Function} fn - Comparison function
- * @returns {Map} New map with the entries sorted
+ * @returns {object} New object with the entries sorted
  */
-export function sortMap (map, fn) {
-	if (!map) {
-		return map;
+export function sortObject (obj, fn) {
+	if (!obj) {
+		return obj;
 	}
 
-	let ret = new Map();
-	for (let [key, value] of [...map.entries()].sort(fn)) {
-		ret.set(key, value);
-	}
-
-	return ret;
+	return Object.fromEntries(Object.entries(obj).sort(fn));
 }


### PR DESCRIPTION
In this PR, we reorder props and their dependents according to the dependency graph. This means that when we initialize props, update dependencies, etc., we work with props, respecting their order in the dependency graph. This should fix the issues when we update props in the wrong order.