### PR TITLE
Ensure the `mixinsApplied` property exists directly on the class

### DIFF
--- a/src/mixins/apply-mixins.js
+++ b/src/mixins/apply-mixins.js
@@ -19,7 +19,7 @@ export function applyMixins (Class, mixins = Class.mixins) {
 }
 
 export function applyMixin(Class, mixin, config) {
-	if (!Class.mixinsApplied) {
+	if (!Object.hasOwn(Class, "mixinsApplied")) {
 		Class.mixinsApplied = [];
 	}
 


### PR DESCRIPTION
Otherwise, previously applied mixins of the parent class (e.g., `NudeElement`) won’t allow the mixins of the class to be used (e.g., none of the `mounted` mixins of child classes will ever be applied).