### PR TITLE
[shadow] Some fixes

### DIFF
--- a/src/shadow/base.js
+++ b/src/shadow/base.js
@@ -24,7 +24,7 @@ export const provides = {
 
 		try {
 			this[shadowRoot] = _attachShadow.call(this, options);
-			this.hooks.run("shadow-attached", {context: this, shadowRoot});
+			this.constructor.hooks.run("shadow-attached", {context: this, shadowRoot});
 		}
 		catch (error) {
 			this[shadowRoot] = null;


### PR DESCRIPTION
- Don’t shadow `attachShadow` from `HTML.prototype`
- Avoid infinite recursion
- Correctly run hooks