### PR TITLE
Fix bugs after switching to the `props` symbol

### DIFF
--- a/src/events/propchange.js
+++ b/src/events/propchange.js
@@ -5,6 +5,7 @@
 
 import symbols from "../plugins/symbols.js";
 import base, { events } from "./base.js";
+import { props } from "../props/base.js";
 
 const { propchange } = symbols.new;
 
@@ -26,7 +27,7 @@ export const hooks = {
 
 			for (let eventName in this[propchange]) {
 				let propName = this[propchange][eventName];
-				let prop = this.props.get(propName);
+				let prop = this[props].get(propName);
 
 				if (prop) {
 					(prop.eventNames ??= []).push(eventName);
@@ -45,9 +46,9 @@ export const hooks = {
 			let value = this[propName];
 
 			if (value !== undefined) {
-				this.constructor.props.firePropChangeEvent(this, eventName, {
+				this.constructor[props].firePropChangeEvent(this, eventName, {
 					name: propName,
-					prop: this.constructor.props.get(propName),
+					prop: this.constructor[props].get(propName),
 				});
 			}
 		}

--- a/src/props/Prop.js
+++ b/src/props/Prop.js
@@ -1,8 +1,6 @@
 import { inferDependencies, resolveValue } from "./util.js";
 import * as types from "./types.js";
 
-import { props } from "../base.js";
-
 let Self = class Prop {
 	/**
 	 * @type {Props} props - The props object this prop belongs to
@@ -117,7 +115,7 @@ let Self = class Prop {
 			delete element[name]; // Deleting the data property will uncover the accessor
 			element[name] = value; // Invoking the accessor means the value doesn't skip parsing
 		}
-		else if (element[props][name] === undefined && !this.defaultProp) {
+		else if (element.props[name] === undefined && !this.defaultProp) {
 			// Is not set and its default is not another prop
 			this.changed(element, { source: "default", element });
 		}
@@ -150,11 +148,11 @@ let Self = class Prop {
 	}
 
 	get (element) {
-		let value = element[props][this.name];
+		let value = element.props[this.name];
 
 		if (value === undefined) {
 			this.update(element);
-			value = element[props][this.name];
+			value = element.props[this.name];
 		}
 
 		if (value === undefined || value === null) {
@@ -185,7 +183,7 @@ let Self = class Prop {
 	}
 
 	set (element, value, { source, name, oldValue } = {}) {
-		let oldInternalValue = element[props][this.name];
+		let oldInternalValue = element.props[this.name];
 
 		let attributeName = name;
 		let parsedValue;
@@ -210,7 +208,7 @@ let Self = class Prop {
 			return;
 		}
 
-		element[props][this.name] = parsedValue;
+		element.props[this.name] = parsedValue;
 
 		let change = {
 			element,
@@ -291,7 +289,7 @@ let Self = class Prop {
 	 * @param {*} element
 	 */
 	update (element, dependency) {
-		let oldValue = element[props][this.name];
+		let oldValue = element.props[this.name];
 
 		if (dependency === this.defaultProp) {
 			// We have no way of checking if the default prop has changed
@@ -322,7 +320,7 @@ let Self = class Prop {
 
 		return (
 			this.dependencies.has(prop.name) ||
-			(this.defaultProp === prop && element[props][this.name] === undefined)
+			(this.defaultProp === prop && element.props[this.name] === undefined)
 		);
 	}
 

--- a/src/props/Props.js
+++ b/src/props/Props.js
@@ -2,8 +2,6 @@ import { sortObject } from "./util.js";
 import Prop from "./Prop.js";
 import PropChangeEvent from "./PropChangeEvent.js";
 
-import { props } from "../base.js";
-
 export default class Props extends Map {
 	/**
 	 * Dependency graph

--- a/src/props/base.js
+++ b/src/props/base.js
@@ -3,7 +3,7 @@ import { defineLazyProperty, symbols } from "../plugins/index.js";
 
 export const { props } = symbols.known;
 
-function setup () {
+function first_constructor_static () {
 	// TODO how does this work if attributeChangedCallback is inherited?
 	let _attributeChangedCallback = this.prototype.attributeChangedCallback;
 	this.prototype.attributeChangedCallback = function (name, oldValue, value) {
@@ -18,20 +18,22 @@ function setup () {
 			configurable: true,
 		});
 	}
-
-	if (this.props) {
-		this.defineProps();
-	}
 }
 
 export const hooks = {
+	setup () {
+		if (this.props) {
+			this.defineProps();
+		}
+	},
+
 	constructor () {
 		if (this.propChangedCallback && this.constructor[props]) {
 			this.addEventListener("propchange", this.propChangedCallback);
 		}
 	},
 
-	setup,
+	first_constructor_static,
 
 	first_connected () {
 		this.constructor[props].initializeFor(this);
@@ -73,7 +75,7 @@ export const providesStatic = {
 
 		this[props] ??= new Props(this);
 
-		let env = {context: this, props: def};
+		let env = { context: this, props: def };
 		this.hooks.run("define-props", env);
 
 		this[props].add(env.props);
@@ -88,4 +90,4 @@ export const providesStatic = {
 	// }),
 };
 
-export default {hooks, provides, providesStatic};
+export default { hooks, provides, providesStatic };


### PR DESCRIPTION
1) Handle `attributeChangedCallback` in the `first_constructed_static` hook, not in the `static` hook.
2) Move the code defining props in the `setup` hook.
3) We still have two kinds of props: the ones on the class itself (accessed via the `props` symbol) and the ones on instances of that class (accessed via the regular `props` property). In short, we shouldn’t confuse `Class[props]` and `element.props`.
4) Remove unused imports.