### PR TITLE
Pass signal equality at construction via { equals } option

### DIFF
--- a/src/plugins/props/util/Prop.js
+++ b/src/plugins/props/util/Prop.js
@@ -142,8 +142,11 @@ let Self = class Prop {
 		let signal = this.#signals.get(element);
 
 		if (!signal) {
+			// Delegate equality to the prop's type-aware equality.
+			let options = { equals: (a, b) => this.equals(a, b) };
+
 			if (this.spec.get) {
-				signal = new Computed(() => this.spec.get.call(element));
+				signal = new Computed(() => this.spec.get.call(element), options);
 				signal.subscribe((newValue, oldValue) => {
 					this.#onComputedChange(element, "get", newValue, oldValue);
 				});
@@ -151,8 +154,7 @@ let Self = class Prop {
 			else if (this.spec.convert || this.spec.default !== undefined) {
 				// Raw Signal holds the user-set value; Computed wraps it to apply
 				// convert and/or fall through to the default. Auto-tracks deps.
-				let rawSignal = new Signal(undefined);
-				rawSignal.equals = (a, b) => this.equals(a, b);
+				let rawSignal = new Signal(undefined, options);
 				this.#rawSignals.set(element, rawSignal);
 
 				let source = this.spec.convert ? "convert" : "default";
@@ -177,17 +179,14 @@ let Self = class Prop {
 						value = this.spec.convert.call(element, value);
 					}
 					return value;
-				});
+				}, options);
 				signal.subscribe((newValue, oldValue) => {
 					this.#onComputedChange(element, source, newValue, oldValue);
 				});
 			}
 			else {
-				signal = new Signal(undefined);
+				signal = new Signal(undefined, options);
 			}
-
-			// Delegate equality to the prop's type-aware equality
-			signal.equals = (a, b) => this.equals(a, b);
 
 			this.#signals.set(element, signal);
 		}

--- a/src/signals.js
+++ b/src/signals.js
@@ -48,9 +48,18 @@ export class Signal extends EventTarget {
 	#value;
 	#subscribers = new Set();
 
-	constructor (value) {
+	/**
+	 * @param {*} value - Initial value.
+	 * @param {object} [options]
+	 * @param {(a: *, b: *) => boolean} [options.equals] - Custom equality
+	 *   check. Set as an instance override of the default `===` method.
+	 */
+	constructor (value, { equals } = {}) {
 		super();
 		this.#value = value;
+		if (equals) {
+			this.equals = equals;
+		}
 	}
 
 	get value () {
@@ -108,9 +117,10 @@ export class Computed extends Signal {
 	/**
 	 * @param {Function} fn - Compute function. All Signal `.value` reads
 	 *   inside this function are auto-tracked as dependencies.
+	 * @param {object} [options] - Forwarded to `Signal` (e.g. `equals`).
 	 */
-	constructor (fn) {
-		super(undefined);
+	constructor (fn, options) {
+		super(undefined, options);
 		this.#fn = fn;
 	}
 

--- a/test/Prop.js
+++ b/test/Prop.js
@@ -544,6 +544,23 @@ export default {
 							},
 							expect: 200,
 						},
+						{
+							name: "spec.equals: tolerated dep change leaves cached value",
+							arg: {
+								props: {
+									base: { type: Number, default: 42 },
+									derived: {
+										get () {
+											return this.base;
+										},
+										equals: (a, b) => Math.abs(a - b) < 0.1,
+									},
+								},
+								actions: [el => (el.base = 42.05)],
+								read: "derived",
+							},
+							expect: 42,
+						},
 					],
 				},
 				{

--- a/test/index.js
+++ b/test/index.js
@@ -1,10 +1,11 @@
 import Prop from "./Prop.js";
 import Props from "./Props.js";
 import hooks from "./hooks.js";
+import signals from "./signals.js";
 import split from "./split.js";
 import plugins from "./plugins/index.js";
 
 export default {
 	name: "All tests",
-	tests: [Prop, Props, hooks, split, plugins],
+	tests: [Prop, Props, hooks, signals, split, plugins],
 };

--- a/test/signals.js
+++ b/test/signals.js
@@ -1,0 +1,33 @@
+import { Signal, Computed } from "../src/signals.js";
+
+export default {
+	name: "Signals",
+	tests: [
+		{
+			name: "Signal honors { equals } option",
+			run () {
+				let signal = new Signal(0, { equals: () => true });
+				let calls = 0;
+				signal.subscribe(() => calls++);
+				signal.value = 1;
+				return calls;
+			},
+			expect: 0,
+		},
+		{
+			name: "Computed honors { equals } option",
+			async run () {
+				let dep = new Signal(0);
+				let computed = new Computed(() => dep.value, { equals: () => true });
+				computed.value;
+
+				let calls = 0;
+				computed.subscribe(() => calls++);
+				dep.value = 5;
+				await Promise.resolve();
+				return calls;
+			},
+			expect: 0,
+		},
+	],
+};


### PR DESCRIPTION
## Summary

Resolves the design discussion at [#91 (comment)](https://github.com/nudeui/element/pull/91#issuecomment-4330525421) (Option 2): replace the post-construction `signal.equals = …` monkey-patches in [Prop.js](https://github.com/nudeui/element/blob/signals-props/src/plugins/props/util/Prop.js) with a constructor option, so signal equality is set up where the signal is born instead of two lines later.

## What's in the PR

### `src/signals.js`

- `Signal` constructor accepts an optional `{ equals }` second argument and applies it as an instance override of the prototype's default `===` method.
- `Computed` constructor takes an `options` parameter and forwards it to `super(undefined, options)`. `new Computed(fn)` (no options) still works because the `Signal` destructure default kicks in when the second arg is `undefined`.

### `src/plugins/props/util/Prop.js`

- `getSignal` now builds `let options = { equals: (a, b) => this.equals(a, b) }` once per (prop, element) pair and threads it through all four `new Signal` / `new Computed` sites (`spec.get` Computed, raw Signal for default/convert, the wrapping Computed, and the plain-Signal fallback).
- The two post-hoc `signal.equals = (a, b) => this.equals(a, b)` lines are removed.

## Tests

### `test/signals.js` (new)

Direct unit tests on the option itself. Both `Signal` and `Computed` get a one-test entry that passes `equals: () => true` (a function that contradicts default `===` — claims every value is equal to every other) and asserts that no subscriber notification fires from a write. With the option wired, `calls === 0`; with default `===`, the signal would notify (`calls === 1`), so the test discriminates.

### `test/Prop.js`

One integration test in the existing `Final value` group: `spec.equals: tolerated dep change leaves cached value`. A `spec.get`-based prop with a tolerance equality function reads from a base prop; a within-tolerance change to the base leaves the Computed's cached value untouched, because `spec.equals` (threaded through the new option to the Computed's `equals` method) treats the recomputed value as equal to the old.

Verified to fail when the option is removed from any of the four `Prop.js` construction sites — without the option, the Computed falls back to default `===` and updates its cache on the dep change. An earlier event-list version of this test was abandoned because hTest's default deep array check at [`check.js:61`](https://github.com/LeaVerou/htest/blob/main/src/check.js#L61) prefix-matches actual against expected, silently tolerating extra trailing events.

## Test plan

- [x] `npm test` — 81 / 84 PASS, 3 pre-existing skips, 0 FAIL.
- [x] Lint (`npx eslint <changed files>`) — 0 errors.
- [x] Regression-catch verified: temporarily removed the option from `new Computed(() => this.spec.get.call(element), options)` ([Prop.js:149](https://github.com/nudeui/element/blob/signals-props/src/plugins/props/util/Prop.js#L149)); the integration test failed with `Got 42.05, expected 42`. Restored.