### PR TITLE
Populate detail on first_connected shortcut re-fires

### DIFF
--- a/src/plugins/events/propchange.js
+++ b/src/plugins/events/propchange.js
@@ -6,6 +6,7 @@
 import { symbols } from "xtensible";
 import base, { events } from "./base.js";
 import { props } from "../props/index.js";
+import PropChangeEvent from "../props/util/PropChangeEvent.js";
 
 const { propchange } = symbols.new;
 
@@ -45,12 +46,13 @@ const hooks = {
 			let propName = this.constructor[propchange][eventName];
 			let value = this[propName];
 
-			if (value !== undefined) {
-				this.constructor[props].firePropChangeEvent(this, eventName, {
-					name: propName,
-					prop: this.constructor[props].get(propName),
-				});
+			if (value === undefined) {
+				continue;
 			}
+
+			let prop = this.constructor[props].get(propName);
+			let detail = { source: "initial", value };
+			this.dispatchEvent(new PropChangeEvent(eventName, { name: propName, prop, detail }));
 		}
 	},
 };


### PR DESCRIPTION
## Summary

`first_connected` re-fires shortcut events for late-bound `on*=` handlers, but dispatched them with **no `detail`**. A listener reading `e.detail.value` crashed on the catch-up while succeeding on the regular dispatch.

Populate a minimal detail: `{ source: "initial", value }`. `source: "initial"` is a new enum value marking the synthetic catch-up.

## Why

Found integration-testing against [color-elements](https://github.com/leaverou/color-elements). `<space-picker value="oklab" onspacechange="…">` attaches its listener via the `onspacechange=` attribute *after* the element has constructed and connected — so the late-bound listener only sees the catch-up dispatch.

## Scope

Extracted from #102 (commit `72e605d`) so it can land independently — pre-existing bug, unrelated to that PR's batching.

## Test plan

- [x] `npm test -- --ci` — 97/98 PASS, 1 pre-existing skip, 0 FAIL
- [x] Manually verified end-to-end against `color-elements`

No unit test added — the catch-up path needs `customElements.define` + real DOM, which the JS-first FakeElement infrastructure doesn't provide.