### PR TITLE
Restore pre-signals defaults / reflection behavior (closes #105)

### DIFF
--- a/src/plugins/props/README.md
+++ b/src/plugins/props/README.md
@@ -163,3 +163,5 @@ The `reflect` property takes the following values:
     - `to`: If `true`, reflect to the attribute with the same name as the prop. If a string, reflect to the attribute with the given name.
 
 By default, `reflect` is `true` **unless** `get` is also specified, in which case it defaults to `false`.
+
+**Defaults are not reflected to attributes** — only user-set values are. Restoring the default (via `el.prop = undefined` or `removeAttribute`) clears any previously-reflected attribute.

--- a/src/plugins/props/util/Prop.js
+++ b/src/plugins/props/util/Prop.js
@@ -104,9 +104,10 @@ let Self = class Prop {
 	#onComputedChange (element, source, newValue, oldValue) {
 		element.props[this.name] = newValue;
 
-		// `null` for defaults: don't synthesize an attribute (would clobber pre-mount
-		// writes — #105) and clear any stale attribute left over from a prior write.
+		// Reflect to attribute if this prop opts in
 		if (this.toAttribute) {
+			// Don't synthesize attributes for defaults (it would clobber pre-mount writes; see #105).
+			// Clear any stale attribute left over from a prior write.
 			let attributeValue = source === "default" ? null : this.stringify(newValue);
 			let oldAttributeValue = element.getAttribute(this.toAttribute);
 			if (oldAttributeValue !== attributeValue) {

--- a/src/plugins/props/util/Prop.js
+++ b/src/plugins/props/util/Prop.js
@@ -165,6 +165,7 @@ let Self = class Prop {
 				let rawSignal = new Signal(undefined, options);
 				this.#rawSignals.set(element, rawSignal);
 
+				let source = this.spec.convert ? "convert" : "property";
 				signal = new Computed(() => {
 					let value = rawSignal.value;
 					if (value === undefined && this.spec.default !== undefined) {
@@ -188,14 +189,8 @@ let Self = class Prop {
 					return value;
 				}, options);
 				signal.subscribe((newValue, oldValue) => {
-					let source =
-						rawSignal.value === undefined
-							? "default"
-							: this.spec.convert
-								? "convert"
-								: "property";
-
-					this.#onComputedChange(element, source, newValue, oldValue);
+					let newSource = rawSignal.value === undefined ? "default" : source;
+					this.#onComputedChange(element, newSource, newValue, oldValue);
 				});
 			}
 			else {

--- a/src/plugins/props/util/Prop.js
+++ b/src/plugins/props/util/Prop.js
@@ -278,6 +278,13 @@ let Self = class Prop {
 			return;
 		}
 
+		// removeAttribute() arrives as null; collapse to undefined so the prop
+		// reverts to its natural empty state (default, if any, otherwise just
+		// undefined). Property writes of null remain a legitimate user value.
+		if (source === "attribute" && parsedValue === null) {
+			parsedValue = undefined;
+		}
+
 		if (this.equals(parsedValue, oldInternalValue)) {
 			return;
 		}

--- a/src/plugins/props/util/Prop.js
+++ b/src/plugins/props/util/Prop.js
@@ -146,7 +146,8 @@ let Self = class Prop {
 		let signal = this.#signals.get(element);
 
 		if (!signal) {
-			// `forceNotify` so explicit user writes still reach the subscriber when
+			// Delegate equality to the prop's type-aware equality.
+			// Explicit user writes still reach the subscriber when
 			// the Computed dedupes against a cached default-resolved value (#105).
 			let options = { equals: (a, b) => this.equals(a, b), forceNotify: true };
 

--- a/src/plugins/props/util/Prop.js
+++ b/src/plugins/props/util/Prop.js
@@ -121,7 +121,7 @@ let Self = class Prop {
 			}
 		}
 
-		// Gate event on value change (the Computed uses forceNotify).
+		// Gate event on value change (the Computed uses force).
 		if (this.equals(newValue, oldValue)) {
 			return;
 		}
@@ -151,7 +151,7 @@ let Self = class Prop {
 			// Delegate equality to the prop's type-aware equality.
 			// Explicit user writes still reach the subscriber when
 			// the Computed dedupes against a cached default-resolved value (#105).
-			let options = { equals: (a, b) => this.equals(a, b), forceNotify: true };
+			let options = { equals: (a, b) => this.equals(a, b), force: true };
 
 			if (this.spec.get) {
 				signal = new Computed(() => this.spec.get.call(element), options);

--- a/src/plugins/props/util/Prop.js
+++ b/src/plugins/props/util/Prop.js
@@ -122,14 +122,16 @@ let Self = class Prop {
 		}
 
 		// Gate event on value change (the Computed uses forceNotify).
-		if (!this.equals(newValue, oldValue)) {
-			this.changed(element, {
-				element,
-				source,
-				parsedValue: newValue,
-				oldInternalValue: oldValue,
-			});
+		if (this.equals(newValue, oldValue)) {
+			return;
 		}
+
+		this.changed(element, {
+			element,
+			source,
+			parsedValue: newValue,
+			oldInternalValue: oldValue,
+		});
 	}
 
 	/**

--- a/src/plugins/props/util/Prop.js
+++ b/src/plugins/props/util/Prop.js
@@ -122,7 +122,7 @@ let Self = class Prop {
 			}
 		}
 
-		// Gate event on value change (the Computed uses force).
+		// Gate event on value change (the Computed uses notifyOnEquals).
 		if (this.equals(newValue, oldValue)) {
 			return;
 		}
@@ -152,7 +152,7 @@ let Self = class Prop {
 			// Delegate equality to the prop's type-aware equality.
 			// Explicit user writes still reach the subscriber when
 			// the Computed dedupes against a cached default-resolved value (#105).
-			let options = { equals: (a, b) => this.equals(a, b), force: true };
+			let options = { equals: (a, b) => this.equals(a, b), notifyOnEquals: true };
 
 			if (this.spec.get) {
 				signal = new Computed(() => this.spec.get.call(element), options);

--- a/src/plugins/props/util/Prop.js
+++ b/src/plugins/props/util/Prop.js
@@ -104,9 +104,10 @@ let Self = class Prop {
 	#onComputedChange (element, source, newValue, oldValue) {
 		element.props[this.name] = newValue;
 
-		// Reflect to attribute if this prop opts in
+		// `null` for defaults: don't synthesize an attribute (would clobber pre-mount
+		// writes — #105) and clear any stale attribute left over from a prior write.
 		if (this.toAttribute) {
-			let attributeValue = this.stringify(newValue);
+			let attributeValue = source === "default" ? null : this.stringify(newValue);
 			let oldAttributeValue = element.getAttribute(this.toAttribute);
 			if (oldAttributeValue !== attributeValue) {
 				element.ignoredAttributes.add(this.toAttribute);
@@ -157,7 +158,6 @@ let Self = class Prop {
 				let rawSignal = new Signal(undefined, options);
 				this.#rawSignals.set(element, rawSignal);
 
-				let source = this.spec.convert ? "convert" : "default";
 				signal = new Computed(() => {
 					let value = rawSignal.value;
 					if (value === undefined && this.spec.default !== undefined) {
@@ -181,6 +181,13 @@ let Self = class Prop {
 					return value;
 				}, options);
 				signal.subscribe((newValue, oldValue) => {
+					let source =
+						rawSignal.value === undefined
+							? "default"
+							: this.spec.convert
+								? "convert"
+								: "property";
+
 					this.#onComputedChange(element, source, newValue, oldValue);
 				});
 			}

--- a/src/plugins/props/util/Prop.js
+++ b/src/plugins/props/util/Prop.js
@@ -121,12 +121,15 @@ let Self = class Prop {
 			}
 		}
 
-		this.changed(element, {
-			element,
-			source,
-			parsedValue: newValue,
-			oldInternalValue: oldValue,
-		});
+		// Gate event on value change (the Computed uses forceNotify).
+		if (!this.equals(newValue, oldValue)) {
+			this.changed(element, {
+				element,
+				source,
+				parsedValue: newValue,
+				oldInternalValue: oldValue,
+			});
+		}
 	}
 
 	/**
@@ -143,8 +146,9 @@ let Self = class Prop {
 		let signal = this.#signals.get(element);
 
 		if (!signal) {
-			// Delegate equality to the prop's type-aware equality.
-			let options = { equals: (a, b) => this.equals(a, b) };
+			// `forceNotify` so explicit user writes still reach the subscriber when
+			// the Computed dedupes against a cached default-resolved value (#105).
+			let options = { equals: (a, b) => this.equals(a, b), forceNotify: true };
 
 			if (this.spec.get) {
 				signal = new Computed(() => this.spec.get.call(element), options);

--- a/src/plugins/props/util/Prop.js
+++ b/src/plugins/props/util/Prop.js
@@ -146,17 +146,11 @@ let Self = class Prop {
 						return;
 					}
 
+					let resolved = this.spec.convert
+						? this.spec.convert.call(element, value)
+						: value;
 					let attributeName = this.toAttribute;
-					let attributeValue;
-					if (value == null) {
-						attributeValue = null;
-					}
-					else {
-						let resolved = this.spec.convert
-							? this.spec.convert.call(element, value)
-							: value;
-						attributeValue = this.stringify(resolved);
-					}
+					let attributeValue = this.stringify(resolved);
 
 					if (element.getAttribute(attributeName) === attributeValue) {
 						return;
@@ -189,7 +183,7 @@ let Self = class Prop {
 							}
 						}
 					}
-					if (value != undefined && this.spec.convert) {
+					if (this.spec.convert) {
 						value = this.spec.convert.call(element, value);
 					}
 					return value;

--- a/src/plugins/props/util/Prop.js
+++ b/src/plugins/props/util/Prop.js
@@ -141,29 +141,27 @@ let Self = class Prop {
 				this.#rawSignals.set(element, rawSignal);
 
 				// Reflect to attribute (if this prop opts in) when the raw user-set value changes
-				rawSignal.subscribe(value => {
-					if (!this.toAttribute) {
-						return;
-					}
+				let attributeName = this.toAttribute;
+				if (attributeName) {
+					rawSignal.subscribe(value => {
+						let resolved = this.spec.convert
+							? this.spec.convert.call(element, value)
+							: value;
+						let attributeValue = this.stringify(resolved);
 
-					let resolved = this.spec.convert
-						? this.spec.convert.call(element, value)
-						: value;
-					let attributeName = this.toAttribute;
-					let attributeValue = this.stringify(resolved);
+						if (element.getAttribute(attributeName) === attributeValue) {
+							return;
+						}
 
-					if (element.getAttribute(attributeName) === attributeValue) {
-						return;
-					}
-
-					element.ignoredAttributes.add(attributeName);
-					this.applyChange(element, {
-						source: "attribute",
-						attributeName,
-						attributeValue,
+						element.ignoredAttributes.add(attributeName);
+						this.applyChange(element, {
+							source: "attribute",
+							attributeName,
+							attributeValue,
+						});
+						element.ignoredAttributes.delete(attributeName);
 					});
-					element.ignoredAttributes.delete(attributeName);
-				});
+				}
 
 				let source = this.spec.convert ? "convert" : "property";
 				signal = new Computed(() => {

--- a/src/plugins/props/util/Prop.js
+++ b/src/plugins/props/util/Prop.js
@@ -98,15 +98,10 @@ let Self = class Prop {
 
 	/**
 	 * Subscriber for Computed signals (spec.get, spec.convert, spec.default).
-	 * Updates element.props cache, reflects to attributes if opted in,
-	 * and fires propchange events.
+	 * Updates element.props cache and fires propchange events.
 	 */
 	#onComputedChange (element, source, newValue, oldValue) {
 		element.props[this.name] = newValue;
-
-		// Defaults don't synthesize attributes (would clobber pre-mount writes; see #105);
-		// passing `null` clears any stale attribute left from a prior user write.
-		this.#reflect(element, source === "default" ? null : newValue);
 
 		this.changed(element, {
 			element,
@@ -114,30 +109,6 @@ let Self = class Prop {
 			parsedValue: newValue,
 			oldInternalValue: oldValue,
 		});
-	}
-
-	/**
-	 * The single reflection site, called from both user writes (`prop.set`) and
-	 * dep-driven recomputes (`#onComputedChange`). Mirrors pre-signals' shape
-	 * where `set()` was the one place attribute reflection happened.
-	 *
-	 * @param {HTMLElement} element
-	 * @param {*} value - Post-convert value to reflect; `null` removes the attribute.
-	 */
-	#reflect (element, value) {
-		if (!this.toAttribute) {
-			return;
-		}
-
-		let attributeName = this.toAttribute;
-		let attributeValue = this.stringify(value);
-		if (element.getAttribute(attributeName) === attributeValue) {
-			return;
-		}
-
-		element.ignoredAttributes.add(attributeName);
-		this.applyChange(element, { source: "attribute", attributeName, attributeValue });
-		element.ignoredAttributes.delete(attributeName);
 	}
 
 	/**
@@ -168,6 +139,37 @@ let Self = class Prop {
 				// convert and/or fall through to the default. Auto-tracks deps.
 				let rawSignal = new Signal(undefined, options);
 				this.#rawSignals.set(element, rawSignal);
+
+				// Reflect to attribute (if this prop opts in) when the raw user-set value changes
+				rawSignal.subscribe(value => {
+					if (!this.toAttribute) {
+						return;
+					}
+
+					let attributeName = this.toAttribute;
+					let attributeValue;
+					if (value == null) {
+						attributeValue = null;
+					}
+					else {
+						let resolved = this.spec.convert
+							? this.spec.convert.call(element, value)
+							: value;
+						attributeValue = this.stringify(resolved);
+					}
+
+					if (element.getAttribute(attributeName) === attributeValue) {
+						return;
+					}
+
+					element.ignoredAttributes.add(attributeName);
+					this.applyChange(element, {
+						source: "attribute",
+						attributeName,
+						attributeValue,
+					});
+					element.ignoredAttributes.delete(attributeName);
+				});
 
 				let source = this.spec.convert ? "convert" : "property";
 				signal = new Computed(() => {
@@ -296,25 +298,9 @@ let Self = class Prop {
 		}
 
 		if (rawSignal) {
-			// Computed-backed: write to the raw signal. The Computed recomputes,
-			// and its subscriber (#onComputedChange) handles element.props and events.
+			// Computed-backed: write to the raw signal. Its subscribers handle
+			// reflection, element.props, and events.
 			rawSignal.value = parsedValue;
-
-			// Why reflect here too, when the subscriber already calls `#reflect`?
-			// - The Computed dedupes recomputes whose new value equals its
-			//   cached value. `el.v = 5` when the default resolves to 5 produces
-			//   no subscriber fire, so reflection from `#onComputedChange` is
-			//   skipped (#105).
-			// - We can't read `signal.value` to get the post-convert form: that
-			//   would force a sync recompute, fire subscribers immediately, and
-			//   split multi-prop dep cascades across two propchange drains.
-			// So apply `spec.convert` manually and call `#reflect` directly.
-			if (source === "property" && parsedValue !== undefined) {
-				this.#reflect(
-					element,
-					this.spec.convert ? this.spec.convert.call(element, parsedValue) : parsedValue,
-				);
-			}
 		}
 		else {
 			// For plain props: update signal, element.props, reflect, and fire events

--- a/src/plugins/props/util/Prop.js
+++ b/src/plugins/props/util/Prop.js
@@ -104,28 +104,9 @@ let Self = class Prop {
 	#onComputedChange (element, source, newValue, oldValue) {
 		element.props[this.name] = newValue;
 
-		// Reflect to attribute if this prop opts in
-		if (this.toAttribute) {
-			// Don't synthesize attributes for defaults (it would clobber pre-mount writes; see #105).
-			// Clear any stale attribute left over from a prior write.
-			let attributeValue = source === "default" ? null : this.stringify(newValue);
-			let oldAttributeValue = element.getAttribute(this.toAttribute);
-			if (oldAttributeValue !== attributeValue) {
-				element.ignoredAttributes.add(this.toAttribute);
-				if (attributeValue === null) {
-					element.removeAttribute(this.toAttribute);
-				}
-				else {
-					element.setAttribute(this.toAttribute, attributeValue);
-				}
-				element.ignoredAttributes.delete(this.toAttribute);
-			}
-		}
-
-		// Gate event on value change (the Computed uses notifyOnEquals).
-		if (this.equals(newValue, oldValue)) {
-			return;
-		}
+		// Defaults don't synthesize attributes (would clobber pre-mount writes; see #105);
+		// passing `null` clears any stale attribute left from a prior user write.
+		this.#reflect(element, source === "default" ? null : newValue);
 
 		this.changed(element, {
 			element,
@@ -133,6 +114,30 @@ let Self = class Prop {
 			parsedValue: newValue,
 			oldInternalValue: oldValue,
 		});
+	}
+
+	/**
+	 * The single reflection site, called from both user writes (`prop.set`) and
+	 * dep-driven recomputes (`#onComputedChange`). Mirrors pre-signals' shape
+	 * where `set()` was the one place attribute reflection happened.
+	 *
+	 * @param {HTMLElement} element
+	 * @param {*} value - Post-convert value to reflect; `null` removes the attribute.
+	 */
+	#reflect (element, value) {
+		if (!this.toAttribute) {
+			return;
+		}
+
+		let attributeName = this.toAttribute;
+		let attributeValue = this.stringify(value);
+		if (element.getAttribute(attributeName) === attributeValue) {
+			return;
+		}
+
+		element.ignoredAttributes.add(attributeName);
+		this.applyChange(element, { source: "attribute", attributeName, attributeValue });
+		element.ignoredAttributes.delete(attributeName);
 	}
 
 	/**
@@ -150,9 +155,7 @@ let Self = class Prop {
 
 		if (!signal) {
 			// Delegate equality to the prop's type-aware equality.
-			// Explicit user writes still reach the subscriber when
-			// the Computed dedupes against a cached default-resolved value (#105).
-			let options = { equals: (a, b) => this.equals(a, b), notifyOnEquals: true };
+			let options = { equals: (a, b) => this.equals(a, b) };
 
 			if (this.spec.get) {
 				signal = new Computed(() => this.spec.get.call(element), options);
@@ -294,9 +297,24 @@ let Self = class Prop {
 
 		if (rawSignal) {
 			// Computed-backed: write to the raw signal. The Computed recomputes,
-			// and its subscriber (#onComputedChange) handles element.props,
-			// reflection, and events.
+			// and its subscriber (#onComputedChange) handles element.props and events.
 			rawSignal.value = parsedValue;
+
+			// Why reflect here too, when the subscriber already calls `#reflect`?
+			// - The Computed dedupes recomputes whose new value equals its
+			//   cached value. `el.v = 5` when the default resolves to 5 produces
+			//   no subscriber fire, so reflection from `#onComputedChange` is
+			//   skipped (#105).
+			// - We can't read `signal.value` to get the post-convert form: that
+			//   would force a sync recompute, fire subscribers immediately, and
+			//   split multi-prop dep cascades across two propchange drains.
+			// So apply `spec.convert` manually and call `#reflect` directly.
+			if (source === "property" && parsedValue !== undefined) {
+				this.#reflect(
+					element,
+					this.spec.convert ? this.spec.convert.call(element, parsedValue) : parsedValue,
+				);
+			}
 		}
 		else {
 			// For plain props: update signal, element.props, reflect, and fire events
@@ -347,7 +365,9 @@ let Self = class Prop {
 			if (element.setAttribute) {
 				let attributeName = change.attributeName ?? this.toAttribute;
 				let attributeValue =
-					change.attributeValue ?? change.element.getAttribute(attributeName);
+					change.attributeValue !== undefined
+						? change.attributeValue
+						: change.element.getAttribute(attributeName);
 
 				if (attributeValue === null) {
 					element.removeAttribute(attributeName);

--- a/src/signals.js
+++ b/src/signals.js
@@ -47,21 +47,21 @@ function flushDirty () {
 export class Signal extends EventTarget {
 	#value;
 	#subscribers = new Set();
-	#forceNotify;
+	#force;
 
 	/**
 	 * @param {*} value - Initial value.
 	 * @param {object} [options]
 	 * @param {(a: *, b: *) => boolean} [options.equals] - Custom equality
 	 *   check. Set as an instance override of the default `===` method.
-	 * @param {boolean} [options.forceNotify=false] - If true, subscribers fire on
-	 *   every write, even when `equals` reports no change. The cached value
+	 * @param {boolean} [options.force=false] - If true, subscribers are notified
+	 *   on every write, even when `equals` reports no change. The cached value
 	 *   still respects `equals` (no-op writes don't update it).
 	 */
-	constructor (value, { equals, forceNotify = false } = {}) {
+	constructor (value, { equals, force = false } = {}) {
 		super();
 		this.#value = value;
-		this.#forceNotify = forceNotify;
+		this.#force = force;
 		if (equals) {
 			this.equals = equals;
 		}
@@ -74,7 +74,7 @@ export class Signal extends EventTarget {
 
 	set value (v) {
 		let same = this.equals(v, this.#value);
-		if (same && !this.#forceNotify) {
+		if (same && !this.#force) {
 			return;
 		}
 
@@ -195,7 +195,7 @@ export class Computed extends Signal {
 			}));
 		}
 
-		// Delegate the equals/forceNotify decision to the Signal setter.
+		// Delegate the equals/force decision to the Signal setter.
 		// Use Signal.prototype.value setter directly (bypasses no-op Computed setter).
 		Object.getOwnPropertyDescriptor(Signal.prototype, "value").set.call(this, value);
 	}

--- a/src/signals.js
+++ b/src/signals.js
@@ -54,7 +54,7 @@ export class Signal extends EventTarget {
 	 * @param {object} [options]
 	 * @param {(a: *, b: *) => boolean} [options.equals] - Custom equality
 	 *   check. Set as an instance override of the default `===` method.
-	 * @param {boolean} [options.forceNotify] - If true, subscribers fire on
+	 * @param {boolean} [options.forceNotify=false] - If true, subscribers fire on
 	 *   every write, even when `equals` reports no change. The cached value
 	 *   still respects `equals` (no-op writes don't update it).
 	 */

--- a/src/signals.js
+++ b/src/signals.js
@@ -47,21 +47,21 @@ function flushDirty () {
 export class Signal extends EventTarget {
 	#value;
 	#subscribers = new Set();
-	#force;
+	#notifyOnEquals;
 
 	/**
 	 * @param {*} value - Initial value.
 	 * @param {object} [options]
 	 * @param {(a: *, b: *) => boolean} [options.equals] - Custom equality
 	 *   check. Set as an instance override of the default `===` method.
-	 * @param {boolean} [options.force=false] - If true, subscribers are notified
-	 *   on every write, even when `equals` reports no change. The cached value
-	 *   still respects `equals` (no-op writes don't update it).
+	 * @param {boolean} [options.notifyOnEquals=false] - If true, subscribers are
+	 *   notified on every write, even when `equals` reports no change. The cached
+	 *   value still respects `equals` (no-op writes don't update it).
 	 */
-	constructor (value, { equals, force = false } = {}) {
+	constructor (value, { equals, notifyOnEquals = false } = {}) {
 		super();
 		this.#value = value;
-		this.#force = force;
+		this.#notifyOnEquals = notifyOnEquals;
 		if (equals) {
 			this.equals = equals;
 		}
@@ -74,7 +74,7 @@ export class Signal extends EventTarget {
 
 	set value (v) {
 		if (this.equals(v, this.#value)) {
-			if (this.#force) {
+			if (this.#notifyOnEquals) {
 				this.#notify(this.#value);
 			}
 			return;
@@ -195,7 +195,7 @@ export class Computed extends Signal {
 			}));
 		}
 
-		// Delegate the equals/force decision to the Signal setter.
+		// Delegate the equals/notifyOnEquals decision to the Signal setter.
 		// Use Signal.prototype.value setter directly (bypasses no-op Computed setter).
 		Object.getOwnPropertyDescriptor(Signal.prototype, "value").set.call(this, value);
 	}

--- a/src/signals.js
+++ b/src/signals.js
@@ -74,10 +74,9 @@ export class Signal extends EventTarget {
 
 	set value (v) {
 		if (this.equals(v, this.#value)) {
-			if (!this.#force) {
-				return;
+			if (this.#force) {
+				this.#notify(this.#value);
 			}
-			this.#notify(this.#value);
 			return;
 		}
 

--- a/src/signals.js
+++ b/src/signals.js
@@ -73,15 +73,16 @@ export class Signal extends EventTarget {
 	}
 
 	set value (v) {
-		let same = this.equals(v, this.#value);
-		if (same && !this.#force) {
+		if (this.equals(v, this.#value)) {
+			if (!this.#force) {
+				return;
+			}
+			this.#notify(this.#value);
 			return;
 		}
 
 		let old = this.#value;
-		if (!same) {
-			this.#value = v;
-		}
+		this.#value = v;
 		this.#notify(old);
 	}
 

--- a/src/signals.js
+++ b/src/signals.js
@@ -47,16 +47,21 @@ function flushDirty () {
 export class Signal extends EventTarget {
 	#value;
 	#subscribers = new Set();
+	#forceNotify;
 
 	/**
 	 * @param {*} value - Initial value.
 	 * @param {object} [options]
 	 * @param {(a: *, b: *) => boolean} [options.equals] - Custom equality
 	 *   check. Set as an instance override of the default `===` method.
+	 * @param {boolean} [options.forceNotify] - If true, subscribers fire on
+	 *   every write, even when `equals` reports no change. The cached value
+	 *   still respects `equals` (no-op writes don't update it).
 	 */
-	constructor (value, { equals } = {}) {
+	constructor (value, { equals, forceNotify = false } = {}) {
 		super();
 		this.#value = value;
+		this.#forceNotify = forceNotify;
 		if (equals) {
 			this.equals = equals;
 		}
@@ -68,12 +73,15 @@ export class Signal extends EventTarget {
 	}
 
 	set value (v) {
-		if (this.equals(v, this.#value)) {
+		let same = this.equals(v, this.#value);
+		if (same && !this.#forceNotify) {
 			return;
 		}
 
 		let old = this.#value;
-		this.#value = v;
+		if (!same) {
+			this.#value = v;
+		}
 		this.#notify(old);
 	}
 
@@ -187,17 +195,8 @@ export class Computed extends Signal {
 			}));
 		}
 
-		// Check if value actually changed, and if so, notify subscribers.
-		// Temporarily suspend tracking so the internal read doesn't
-		// register this Computed as a dependency of an outer Computed.
-		let prev2 = tracking;
-		tracking = null;
-		let old = super.value;
-		tracking = prev2;
-
-		if (!this.equals(value, old)) {
-			// Use Signal.prototype.value setter directly (bypasses no-op Computed setter)
-			Object.getOwnPropertyDescriptor(Signal.prototype, "value").set.call(this, value);
-		}
+		// Delegate the equals/forceNotify decision to the Signal setter.
+		// Use Signal.prototype.value setter directly (bypasses no-op Computed setter).
+		Object.getOwnPropertyDescriptor(Signal.prototype, "value").set.call(this, value);
 	}
 }

--- a/src/signals.js
+++ b/src/signals.js
@@ -187,7 +187,6 @@ export class Computed extends Signal {
 			}));
 		}
 
-		// Bypass Computed's read-only setter; Signal#set handles the equals dedupe.
-		Object.getOwnPropertyDescriptor(Signal.prototype, "value").set.call(this, value);
+		super.value = value;
 	}
 }

--- a/src/signals.js
+++ b/src/signals.js
@@ -47,21 +47,16 @@ function flushDirty () {
 export class Signal extends EventTarget {
 	#value;
 	#subscribers = new Set();
-	#notifyOnEquals;
 
 	/**
 	 * @param {*} value - Initial value.
 	 * @param {object} [options]
 	 * @param {(a: *, b: *) => boolean} [options.equals] - Custom equality
 	 *   check. Set as an instance override of the default `===` method.
-	 * @param {boolean} [options.notifyOnEquals=false] - If true, subscribers are
-	 *   notified on every write, even when `equals` reports no change. The cached
-	 *   value still respects `equals` (no-op writes don't update it).
 	 */
-	constructor (value, { equals, notifyOnEquals = false } = {}) {
+	constructor (value, { equals } = {}) {
 		super();
 		this.#value = value;
-		this.#notifyOnEquals = notifyOnEquals;
 		if (equals) {
 			this.equals = equals;
 		}
@@ -74,9 +69,6 @@ export class Signal extends EventTarget {
 
 	set value (v) {
 		if (this.equals(v, this.#value)) {
-			if (this.#notifyOnEquals) {
-				this.#notify(this.#value);
-			}
 			return;
 		}
 
@@ -195,8 +187,7 @@ export class Computed extends Signal {
 			}));
 		}
 
-		// Delegate the equals/notifyOnEquals decision to the Signal setter.
-		// Use Signal.prototype.value setter directly (bypasses no-op Computed setter).
+		// Bypass Computed's read-only setter; Signal#set handles the equals dedupe.
 		Object.getOwnPropertyDescriptor(Signal.prototype, "value").set.call(this, value);
 	}
 }

--- a/test/Prop.js
+++ b/test/Prop.js
@@ -561,6 +561,18 @@ export default {
 							},
 							expect: 42,
 						},
+						{
+							name: "removeAttribute restores default",
+							arg: {
+								props: { v: { type: Number, reflect: true, default: 5 } },
+								actions: [
+									el => el.setAttribute("v", "6"),
+									el => el.removeAttribute("v"),
+								],
+								read: "v",
+							},
+							expect: 5,
+						},
 					],
 				},
 				{
@@ -601,6 +613,39 @@ export default {
 									},
 								},
 								attr: "val",
+							},
+							expect: null,
+						},
+						{
+							name: "removeAttribute clears the reflected attribute",
+							arg: {
+								props: { v: { type: Number, reflect: true, default: 5 } },
+								actions: [
+									el => el.setAttribute("v", "6"),
+									el => el.removeAttribute("v"),
+								],
+								attr: "v",
+							},
+							expect: null,
+						},
+						{
+							name: "Explicit write equal to default still reflects",
+							arg: {
+								props: { v: { type: Number, reflect: true, default: 5 } },
+								actions: [el => (el.v = 5)],
+								attr: "v",
+							},
+							expect: "5",
+						},
+						{
+							name: "Restoring the default clears the previously-reflected attribute",
+							arg: {
+								props: { v: { type: Number, reflect: true, default: 5 } },
+								actions: [
+									el => (el.v = 6),
+									el => (el.v = undefined),
+								],
+								attr: "v",
 							},
 							expect: null,
 						},

--- a/test/Prop.js
+++ b/test/Prop.js
@@ -303,7 +303,7 @@ export default {
 							expect: [
 								"src/default",
 								"mirror/default",
-								"src/default",
+								"src/property",
 								"mirror/default",
 							],
 						},
@@ -372,8 +372,8 @@ export default {
 								"computed/get",
 								"fnDefault/default",
 
-								// Update — Computed-backed: source stays construction-time
-								"plain/default",
+								// Update — source now reports the value's actual origin
+								"plain/property",
 								"computed/get",
 								"fnDefault/default",
 							],
@@ -580,15 +580,15 @@ export default {
 							expect: "42",
 						},
 						{
-							name: "Default + reflect reflects on mount (plain)",
+							name: "Default does NOT reflect on mount (plain)",
 							arg: {
 								props: { plain: { type: Number, default: 7, reflect: true } },
 								attr: "plain",
 							},
-							expect: "7",
+							expect: null,
 						},
 						{
-							name: "Default + convert + reflect reflects on mount",
+							name: "Default does NOT reflect on mount (with convert)",
 							arg: {
 								props: {
 									val: {
@@ -602,7 +602,7 @@ export default {
 								},
 								attr: "val",
 							},
-							expect: "10",
+							expect: null,
 						},
 					],
 				},

--- a/test/Prop.js
+++ b/test/Prop.js
@@ -372,7 +372,7 @@ export default {
 								"computed/get",
 								"fnDefault/default",
 
-								// Update — source now reports the value's actual origin
+								// Update
 								"plain/property",
 								"computed/get",
 								"fnDefault/default",

--- a/test/util/FakeElement.js
+++ b/test/util/FakeElement.js
@@ -16,11 +16,15 @@ export default class FakeElement extends EventTarget {
 	}
 
 	setAttribute (name, value) {
+		let oldValue = this.#attrs.get(name) ?? null;
 		this.#attrs.set(name, String(value));
+		this.constructor.props?.attributeChanged(this, name, oldValue);
 	}
 
 	removeAttribute (name) {
+		let oldValue = this.#attrs.get(name) ?? null;
 		this.#attrs.delete(name);
+		this.constructor.props?.attributeChanged(this, name, oldValue);
 	}
 
 	mount () {


### PR DESCRIPTION
Closes #105.

Restore three default-reflection contracts that the signals migration (#91) regressed. While editing the same `#onComputedChange` conditional, also clear a long-standing latent bug — leaving it would have left #105 partially open. The production color-elements site runs on 0.1.3 (pre-signals); these restore the contracts it relies on, so #102 can ship without regressions in its diff.

## What's restored

| Scenario | Pre-signals | Post-signals (origin/main) | This PR |
|---|---|---|---|
| Default reflects on mount | no | **yes (regression)** | no |
| `removeAttribute(name)` → `el.prop` | default | **null (regression)** | default |
| Explicit `el.prop = X` where `X` matches the default | reflects `"X"` | **no reflection (regression)** | reflects `"X"` |
| Reverting to default leaves a stale reflected attribute from a prior write | **yes (latent)** | yes | no |

The 4th row is a latent bug present even pre-signals: `applyChange`'s `?? element.getAttribute(...)` made explicit `null` mean "fall back to current attribute," so callers had no way to express "remove this attribute" through the change object. This PR fixes both layers — `applyChange` is tightened so callers can actually request removal, and the `rawSignal` subscriber passes `null` when reverting to default.

## Code shape: pre-signals' reflection scope

Pre-signals' `set()` only reflected when `source === "property"` — direct prop writes. Convert-dep, get-dep, and default-dep cascades went through `update()` → `set()` with non-`"property"` sources and fell through the reflection gate. The signals migration moved reflection onto `#onComputedChange` (the Computed's subscriber), which fires on every recompute regardless of trigger. That expansion is the root of #105 (default fallthrough started synthesizing attributes) and of the user-write-equal-to-default reflection gap (the Computed's `equals` dedup skips recomputes whose new value equals the cached value).

This PR moves reflection to a subscriber on `rawSignal`. `rawSignal.value` changes for every `prop.set` call on a Computed-backed prop — user writes (`source: "property"`) and attribute-driven writes (`source: "attribute"`) — and *only* those. That's exactly pre-signals' scope. `#onComputedChange` no longer touches attributes; it just updates `element.props` and fires `propchange`.

## Stats

GitHub shows **+104 / −43 across 5 files**. Most of the diff is tests:

| Category | Net lines | File(s) |
|---|---:|---|
| Source code logic + JSDoc | +10 | Prop.js (+21), signals.js (−11) |
| Documentation | +2 | README.md |
| Adjusted + new regression tests | +45 | test/Prop.js |
| Test infrastructure | +4 | test/util/FakeElement.js (`setAttribute` / `removeAttribute` now call `attributeChanged`, mirroring real custom elements) |

`src/signals.js` is **net −11 lines** — no new Signal API. The redundant equals guard in `Computed#compute` is removed (`Signal#set` decides), and the previous prototype-descriptor walk is replaced with `super.value = value`.

Each new test was confirmed to **fail with its corresponding fix disabled**, then **pass with the fix re-enabled**.

## Implementation

- **`rawSignal.subscribe(...)` in `getSignal`**: the single reflection site. Fires on direct prop writes and attribute-driven writes — the same trigger set pre-signals reflected on. When the raw value is `null`/`undefined` (revert to default or explicit `null` write), clears the attribute; otherwise applies `spec.convert` and reflects the stringified result. The `getAttribute === attributeValue` guard short-circuits attribute-driven writes (the value is already there) and any other no-op.
- **`#onComputedChange`**: only updates `element.props[name]` and fires `propchange`. No reflection.
- **Source derivation**: Compute `source` dynamically in the Computed's subscriber — `"default"` iff `rawSignal.value === undefined`, else the user-write source (`"convert"` or `"property"`).
- **`Prop#set`**: Collapse `null → undefined` when `source === "attribute"`, so `removeAttribute` returns the rawSignal to its empty state and the Computed re-engages the default fallthrough. The `rawSignal` branch is now a single line — the previous inline `#reflect` workaround is gone (the subscriber handles it).
- **`applyChange` `??` → `!== undefined ?`**: Closes the latent bug above. Now explicit `null` means "remove"; only an omitted `attributeValue` falls back to the source element's current attribute.
- **`Computed.#compute`**: writes via `super.value = value` (standard class inheritance) instead of `Object.getOwnPropertyDescriptor(Signal.prototype, "value").set.call(this, value)`. Same observable behavior, no internals interference.

## Why now

PR #102 currently inherits the regressions. Landing this first lets #102 rebase cleanly on a fixed main, so it ships without regressions in its diff.

## Test plan

- [x] `npm test -- --ci` — 85/88 PASS, 3 pre-existing skips, 0 FAIL