### PR TITLE
Fix `setAttribute()` after mount not updating reflected props (closes #98)

### DIFF
--- a/src/plugins/props/index.js
+++ b/src/plugins/props/index.js
@@ -77,7 +77,7 @@ defineLazyProperty(provides, "ignoredAttributes", {
 
 const providesStatic = {
 	defineProps (def = this.props) {
-		if (def instanceof Props && def.Class === this) {
+		if ((def instanceof Props && def.Class === this) || this[props].size > 0) {
 			// Already defined
 			return null;
 		}
@@ -101,11 +101,10 @@ const providesStatic = {
 			return this[observedAttributes];
 		}
 
-		// Reserve the cache before firing setup() so re-entry from a setup hook
-		// reading Class.observedAttributes returns the in-flight list instead of
-		// recursing into setup().
+		// Reserve the cache before defineProps so a `define-props` hook that reads
+		// Class.observedAttributes returns the in-flight list instead of recursing.
 		this[observedAttributes] = [];
-		this.setup();
+		this.defineProps();
 
 		// FIXME how to combine with existing observedAttributes?
 		return (this[observedAttributes] = this[props].observedAttributes);

--- a/src/plugins/props/index.js
+++ b/src/plugins/props/index.js
@@ -4,6 +4,7 @@ import { defineOwnProperty } from "xtensible/util";
 import { defineLazyProperty } from "../../util/lazy.js";
 
 export const { props } = symbols.known;
+const { observedAttributes } = symbols.known;
 
 function first_constructor_static () {
 	// TODO how does this work if attributeChangedCallback is inherited?
@@ -12,14 +13,6 @@ function first_constructor_static () {
 		this.constructor[props].attributeChanged(this, name, oldValue, value);
 		_attributeChangedCallback?.call(this, name, oldValue, value);
 	};
-
-	// FIXME how to combine with existing observedAttributes?
-	if (!Object.hasOwn(this, "observedAttributes")) {
-		Object.defineProperty(this, "observedAttributes", {
-			get: () => this[props].observedAttributes,
-			configurable: true,
-		});
-	}
 }
 
 const hooks = {
@@ -102,6 +95,21 @@ const providesStatic = {
 	// 		return [...superProps, ...thisProps];
 	// 	},
 	// }),
+
+	get observedAttributes () {
+		if (Object.hasOwn(this, observedAttributes)) {
+			return this[observedAttributes];
+		}
+
+		// Reserve the cache before firing setup() so re-entry from a setup hook
+		// reading Class.observedAttributes returns the in-flight list instead of
+		// recursing into setup().
+		this[observedAttributes] = [];
+		this.setup();
+
+		// FIXME how to combine with existing observedAttributes?
+		return (this[observedAttributes] = this[props].observedAttributes);
+	},
 };
 
 defineOwnProperty(providesStatic, props, function () {

--- a/src/plugins/props/index.js
+++ b/src/plugins/props/index.js
@@ -1,6 +1,6 @@
 import Props from "./util/Props.js";
 import { symbols } from "xtensible";
-import { defineOwnProperty } from "xtensible/util";
+import { defineOwnProperty, getSuperMethod } from "xtensible/util";
 import { defineLazyProperty } from "../../util/lazy.js";
 
 export const { props } = symbols.known;
@@ -41,11 +41,15 @@ const hooks = {
 };
 
 const provides = {
-	// ...composed({
-	// 	attributeChangedCallback (name, oldValue, value) {
-	// 		this.constructor[props].attributeChanged(this, name, oldValue, value);
-	// 	},
-	// }),
+	// Must be on the prototype chain by the time customElements.define runs:
+	// the spec only reads observedAttributes if attributeChangedCallback is non-null.
+	// https://html.spec.whatwg.org/multipage/custom-elements.html#element-definition
+	attributeChangedCallback (name, oldValue, value) {
+		// Same as super.attributeChangedCallback?.()
+		getSuperMethod(this, provides.attributeChangedCallback)?.call(this, name, oldValue, value);
+
+		this.constructor[props].attributeChanged(this, name, oldValue, value);
+	},
 };
 
 // Internal prop values
@@ -97,18 +101,6 @@ const providesStatic = {
 		// hook listener) gets the in-flight list instead of recursing.
 		this[observedAttributes] = [];
 		this.defineProps();
-
-		// Must land before customElements.define snapshots the prototype callbacks;
-		// a later patch is invisible to post-mount setAttribute reactions.
-		// https://html.spec.whatwg.org/multipage/custom-elements.html#element-definition
-		// TODO how does this work if attributeChangedCallback is inherited?
-		if (!Object.hasOwn(this.prototype, "attributeChangedCallback")) {
-			let _attributeChangedCallback = this.prototype.attributeChangedCallback;
-			this.prototype.attributeChangedCallback = function (name, oldValue, value) {
-				this.constructor[props].attributeChanged(this, name, oldValue, value);
-				_attributeChangedCallback?.call(this, name, oldValue, value);
-			};
-		}
 
 		// FIXME how to combine with existing observedAttributes?
 		return (this[observedAttributes] = this[props].observedAttributes);

--- a/src/plugins/props/index.js
+++ b/src/plugins/props/index.js
@@ -6,15 +6,6 @@ import { defineLazyProperty } from "../../util/lazy.js";
 export const { props } = symbols.known;
 const { observedAttributes } = symbols.known;
 
-function first_constructor_static () {
-	// TODO how does this work if attributeChangedCallback is inherited?
-	let _attributeChangedCallback = this.prototype.attributeChangedCallback;
-	this.prototype.attributeChangedCallback = function (name, oldValue, value) {
-		this.constructor[props].attributeChanged(this, name, oldValue, value);
-		_attributeChangedCallback?.call(this, name, oldValue, value);
-	};
-}
-
 const hooks = {
 	setup () {
 		// Skip if the static observedAttributes getter already ran the install —
@@ -39,8 +30,6 @@ const hooks = {
 			this.addEventListener("propschange", this.updated);
 		}
 	},
-
-	first_constructor_static,
 
 	constructed () {
 		this.constructor[props].initializeFor(this);
@@ -108,6 +97,18 @@ const providesStatic = {
 		// hook listener) gets the in-flight list instead of recursing.
 		this[observedAttributes] = [];
 		this.defineProps();
+
+		// Must land before customElements.define snapshots the prototype callbacks;
+		// a later patch is invisible to post-mount setAttribute reactions.
+		// https://html.spec.whatwg.org/multipage/custom-elements.html#element-definition
+		// TODO how does this work if attributeChangedCallback is inherited?
+		if (!Object.hasOwn(this.prototype, "attributeChangedCallback")) {
+			let _attributeChangedCallback = this.prototype.attributeChangedCallback;
+			this.prototype.attributeChangedCallback = function (name, oldValue, value) {
+				this.constructor[props].attributeChanged(this, name, oldValue, value);
+				_attributeChangedCallback?.call(this, name, oldValue, value);
+			};
+		}
 
 		// FIXME how to combine with existing observedAttributes?
 		return (this[observedAttributes] = this[props].observedAttributes);

--- a/src/plugins/props/index.js
+++ b/src/plugins/props/index.js
@@ -17,7 +17,9 @@ function first_constructor_static () {
 
 const hooks = {
 	setup () {
-		if (Object.hasOwn(this, "props")) {
+		// Skip if the static observedAttributes getter already ran the install —
+		// it's the registration-time path that fires before any instance exists.
+		if (Object.hasOwn(this, "props") && !Object.hasOwn(this, observedAttributes)) {
 			this.defineProps();
 		}
 	},
@@ -77,7 +79,7 @@ defineLazyProperty(provides, "ignoredAttributes", {
 
 const providesStatic = {
 	defineProps (def = this.props) {
-		if ((def instanceof Props && def.Class === this) || this[props].size > 0) {
+		if (def instanceof Props && def.Class === this) {
 			// Already defined
 			return null;
 		}
@@ -101,8 +103,9 @@ const providesStatic = {
 			return this[observedAttributes];
 		}
 
-		// Reserve the cache before defineProps so a `define-props` hook that reads
-		// Class.observedAttributes returns the in-flight list instead of recursing.
+		// Reserve the cache before defineProps so any consumer that reads
+		// Class.observedAttributes during the install (e.g., a define-props
+		// hook listener) gets the in-flight list instead of recursing.
 		this[observedAttributes] = [];
 		this.defineProps();
 

--- a/test/Props.js
+++ b/test/Props.js
@@ -186,5 +186,23 @@ export default {
 				},
 			],
 		},
+		{
+			name: "Class.defineProps()",
+			tests: [
+				{
+					name: "Additive after observedAttributes has populated this[props]",
+					async run () {
+						let { $hook, hooksCommon } = await import("xtensible/plugins");
+						let { default: propsPlugin, props: propsSymbol } =
+							await import("../src/plugins/props/index.js");
+
+						let Class = FakeElement.with({ foo: {} }, $hook, hooksCommon, propsPlugin);
+						Class.defineProps({ bar: {} });
+						return [...Class[propsSymbol].keys()];
+					},
+					expect: ["foo", "bar"],
+				},
+			],
+		},
 	],
 };

--- a/test/Props.js
+++ b/test/Props.js
@@ -1,4 +1,6 @@
 import { default as Props } from "../src/plugins/props/util/Props.js";
+import { default as propsPlugin, props as propsSymbol } from "../src/plugins/props/index.js";
+import { $hook, hooksCommon } from "xtensible/plugins";
 import FakeElement, { flush } from "./util/FakeElement.js";
 
 export default {
@@ -110,11 +112,7 @@ export default {
 						},
 						{
 							name: "Post-mount setAttribute updates the property",
-							async run () {
-								let { $hook, hooksCommon } = await import("xtensible/plugins");
-								let { default: propsPlugin } =
-									await import("../src/plugins/props/index.js");
-
+							run () {
 								let el = new (FakeElement.with(
 									{
 										prop: { type: Number, reflect: true },
@@ -191,16 +189,51 @@ export default {
 			tests: [
 				{
 					name: "Additive after observedAttributes has populated this[props]",
-					async run () {
-						let { $hook, hooksCommon } = await import("xtensible/plugins");
-						let { default: propsPlugin, props: propsSymbol } =
-							await import("../src/plugins/props/index.js");
-
+					run () {
 						let Class = FakeElement.with({ foo: {} }, $hook, hooksCommon, propsPlugin);
 						Class.defineProps({ bar: {} });
 						return [...Class[propsSymbol].keys()];
 					},
 					expect: ["foo", "bar"],
+				},
+			],
+		},
+		{
+			name: "Subclass attributeChangedCallback override",
+			description: "A subclass override must chain via super to compose with the plugin.",
+			run (callSuper) {
+				let Class = FakeElement.with(
+					{ prop: { type: Number, reflect: true } },
+					$hook,
+					hooksCommon,
+					propsPlugin,
+				);
+
+				let pluginCallback = Class.prototype.attributeChangedCallback;
+				Class.prototype.attributeChangedCallback = function (name, oldValue, value) {
+					if (callSuper) {
+						pluginCallback.call(this, name, oldValue, value);
+					}
+				};
+
+				FakeElement.define(Class);
+
+				let el = new Class();
+				el.mount();
+				el.setAttribute("prop", "100");
+
+				return el.prop;
+			},
+			tests: [
+				{
+					name: "Override that calls super updates the reflected prop",
+					arg: true,
+					expect: 100,
+				},
+				{
+					name: "Override that omits super leaves the reflected prop unchanged",
+					arg: false,
+					expect: undefined,
 				},
 			],
 		},

--- a/test/Props.js
+++ b/test/Props.js
@@ -111,9 +111,18 @@ export default {
 						{
 							name: "Post-mount setAttribute updates the property",
 							async run () {
-								let el = new (FakeElement.with({
-									prop: { type: Number, reflect: true },
-								}))();
+								let { $hook, hooksCommon } = await import("xtensible/plugins");
+								let { default: propsPlugin } =
+									await import("../src/plugins/props/index.js");
+
+								let el = new (FakeElement.with(
+									{
+										prop: { type: Number, reflect: true },
+									},
+									$hook,
+									hooksCommon,
+									propsPlugin,
+								))();
 								el.mount();
 								el.setAttribute("prop", "100");
 								return el.prop;

--- a/test/util/FakeElement.js
+++ b/test/util/FakeElement.js
@@ -107,20 +107,26 @@ export default class FakeElement extends EventTarget {
 			};
 		}
 
-		// Snapshot at registration, mirroring customElements.define:
-		// 1. Read attributeChangedCallback from the prototype chain.
-		// 2. ONLY IF non-null, read observedAttributes from the constructor.
-		// https://html.spec.whatwg.org/multipage/custom-elements.html#element-definition
+		FakeElement.define(Class);
+		return Class;
+	}
+
+	/**
+	 * Snapshot lifecycleCallbacks + observedAttributes the way customElements.define does:
+	 * 1. Read attributeChangedCallback from the prototype chain.
+	 * 2. ONLY IF non-null, read observedAttributes from the constructor.
+	 * https://html.spec.whatwg.org/multipage/custom-elements.html#element-definition
+	 *
+	 * Re-callable so a test can swap a class's ACB and re-snapshot, modelling
+	 * a subclass that overrides attributeChangedCallback before registration.
+	 */
+	static define (Class) {
 		let callback = Class.prototype.attributeChangedCallback;
 		Class[definition] = {
 			observedAttributes: callback
-				? plugins.length
-					? Class.observedAttributes
-					: Class.props.observedAttributes
+				? (Class.observedAttributes ?? Class.props?.observedAttributes ?? [])
 				: [],
 			attributeChangedCallback: callback,
 		};
-
-		return Class;
 	}
 }

--- a/test/util/FakeElement.js
+++ b/test/util/FakeElement.js
@@ -107,12 +107,18 @@ export default class FakeElement extends EventTarget {
 			};
 		}
 
-		// Snapshot at registration, like customElements.define builds a CustomElementDefinition.
+		// Snapshot at registration, mirroring customElements.define:
+		// 1. Read attributeChangedCallback from the prototype chain.
+		// 2. ONLY IF non-null, read observedAttributes from the constructor.
+		// https://html.spec.whatwg.org/multipage/custom-elements.html#element-definition
+		let callback = Class.prototype.attributeChangedCallback;
 		Class[definition] = {
-			observedAttributes: plugins.length
-				? Class.observedAttributes
-				: Class.props.observedAttributes,
-			attributeChangedCallback: Class.prototype.attributeChangedCallback,
+			observedAttributes: callback
+				? plugins.length
+					? Class.observedAttributes
+					: Class.props.observedAttributes
+				: [],
+			attributeChangedCallback: callback,
 		};
 
 		return Class;

--- a/test/util/FakeElement.js
+++ b/test/util/FakeElement.js
@@ -4,6 +4,9 @@ import Props from "../../src/plugins/props/util/Props.js";
 /** Same Symbol the props plugin uses for its per-class slot — get-symbols' shared registry. */
 const { props: propsSymbol } = symbols.known;
 
+/** Per-class observedAttributes snapshot, captured at FakeElement.with() time — mirrors customElements.define's one-time read. */
+const defined = Symbol("defined");
+
 /** Yield N microtasks so any queued work runs. */
 export async function flush (ticks = 1) {
 	for (let i = 0; i < ticks; i++) {
@@ -20,18 +23,6 @@ export async function apply (element, actions, ticks = 1) {
 		await flush(ticks);
 	}
 }
-
-/**
- * Per-class observedAttributes captured at FakeElement.with() time, like
- * customElements.define reads them once in the browser.
- *
- * With plugins, read via the plugin's static getter (the customElements.define
- * path); otherwise via the Props instance.
- *
- * setAttribute / removeAttribute consult this to decide whether to fire
- * attributeChanged.
- */
-const defined = new WeakMap();
 
 /** Minimal in-memory element for tests of Prop / Props. */
 export default class FakeElement extends EventTarget {
@@ -75,7 +66,7 @@ export default class FakeElement extends EventTarget {
 	setAttribute (name, value) {
 		let oldValue = this.#attrs.get(name) ?? null;
 		this.#attrs.set(name, String(value));
-		if (defined.get(this.constructor)?.includes(name)) {
+		if (this.constructor[defined]?.includes(name)) {
 			this.constructor.props?.attributeChanged(this, name, oldValue);
 		}
 	}
@@ -83,7 +74,7 @@ export default class FakeElement extends EventTarget {
 	removeAttribute (name) {
 		let oldValue = this.#attrs.get(name) ?? null;
 		this.#attrs.delete(name);
-		if (defined.get(this.constructor)?.includes(name)) {
+		if (this.constructor[defined]?.includes(name)) {
 			this.constructor.props?.attributeChanged(this, name, oldValue);
 		}
 	}
@@ -103,10 +94,8 @@ export default class FakeElement extends EventTarget {
 			Class[propsSymbol] = Class.props;
 		}
 
-		defined.set(
-			Class,
-			plugins.length ? Class.observedAttributes : Class.props.observedAttributes,
-		);
+		// Snapshot observedAttributes once at registration, like customElements.define.
+		Class[defined] = plugins.length ? Class.observedAttributes : Class.props.observedAttributes;
 
 		return Class;
 	}

--- a/test/util/FakeElement.js
+++ b/test/util/FakeElement.js
@@ -1,4 +1,8 @@
+import { addPlugins, symbols } from "xtensible";
 import Props from "../../src/plugins/props/util/Props.js";
+
+/** Same Symbol the props plugin uses for its per-class slot — get-symbols' shared registry. */
+const { props: propsSymbol } = symbols.known;
 
 /** Yield N microtasks so any queued work runs. */
 export async function flush (ticks = 1) {
@@ -16,6 +20,18 @@ export async function apply (element, actions, ticks = 1) {
 		await flush(ticks);
 	}
 }
+
+/**
+ * Per-class observedAttributes captured at FakeElement.with() time, like
+ * customElements.define reads them once in the browser.
+ *
+ * With plugins, read via the plugin's static getter (the customElements.define
+ * path); otherwise via the Props instance.
+ *
+ * setAttribute / removeAttribute consult this to decide whether to fire
+ * attributeChanged.
+ */
+const defined = new WeakMap();
 
 /** Minimal in-memory element for tests of Prop / Props. */
 export default class FakeElement extends EventTarget {
@@ -59,13 +75,17 @@ export default class FakeElement extends EventTarget {
 	setAttribute (name, value) {
 		let oldValue = this.#attrs.get(name) ?? null;
 		this.#attrs.set(name, String(value));
-		this.constructor.props?.attributeChanged(this, name, oldValue);
+		if (defined.get(this.constructor)?.includes(name)) {
+			this.constructor.props?.attributeChanged(this, name, oldValue);
+		}
 	}
 
 	removeAttribute (name) {
 		let oldValue = this.#attrs.get(name) ?? null;
 		this.#attrs.delete(name);
-		this.constructor.props?.attributeChanged(this, name, oldValue);
+		if (defined.get(this.constructor)?.includes(name)) {
+			this.constructor.props?.attributeChanged(this, name, oldValue);
+		}
 	}
 
 	mount () {
@@ -73,10 +93,21 @@ export default class FakeElement extends EventTarget {
 		this.constructor.props.initializeFor(this);
 	}
 
-	/** Build a FakeElement subclass with the given props spec. */
-	static with (props) {
+	/** Build a FakeElement subclass with the given props spec and plugins. */
+	static with (props, ...plugins) {
 		let Class = class extends FakeElement {};
 		Class.props = new Props(Class, props);
+
+		if (plugins.length) {
+			addPlugins(Class, ...plugins);
+			Class[propsSymbol] = Class.props;
+		}
+
+		defined.set(
+			Class,
+			plugins.length ? Class.observedAttributes : Class.props.observedAttributes,
+		);
+
 		return Class;
 	}
 }

--- a/test/util/FakeElement.js
+++ b/test/util/FakeElement.js
@@ -4,8 +4,8 @@ import Props from "../../src/plugins/props/util/Props.js";
 /** Same Symbol the props plugin uses for its per-class slot — get-symbols' shared registry. */
 const { props: propsSymbol } = symbols.known;
 
-/** Per-class observedAttributes snapshot, captured at FakeElement.with() time — mirrors customElements.define's one-time read. */
-const defined = Symbol("defined");
+/** Per-class CustomElementDefinition snapshot, captured at FakeElement.with() time — mirrors customElements.define. */
+const definition = Symbol("definition");
 
 /** Yield N microtasks so any queued work runs. */
 export async function flush (ticks = 1) {
@@ -65,17 +65,23 @@ export default class FakeElement extends EventTarget {
 
 	setAttribute (name, value) {
 		let oldValue = this.#attrs.get(name) ?? null;
-		this.#attrs.set(name, String(value));
-		if (this.constructor[defined]?.includes(name)) {
-			this.constructor.props?.attributeChanged(this, name, oldValue);
+		value = String(value);
+		this.#attrs.set(name, value);
+
+		// Dispatch through the snapshotted attributeChangedCallback, like a real browser.
+		let def = this.constructor[definition];
+		if (def?.observedAttributes.includes(name)) {
+			def.attributeChangedCallback?.call(this, name, oldValue, value);
 		}
 	}
 
 	removeAttribute (name) {
 		let oldValue = this.#attrs.get(name) ?? null;
 		this.#attrs.delete(name);
-		if (this.constructor[defined]?.includes(name)) {
-			this.constructor.props?.attributeChanged(this, name, oldValue);
+
+		let def = this.constructor[definition];
+		if (def?.observedAttributes.includes(name)) {
+			def.attributeChangedCallback?.call(this, name, oldValue, null);
 		}
 	}
 
@@ -93,9 +99,21 @@ export default class FakeElement extends EventTarget {
 			addPlugins(Class, ...plugins);
 			Class[propsSymbol] = Class.props;
 		}
+		else {
+			// No plugins: simulate the registration-time install the props plugin
+			// would perform, so the ACB snapshot below has something to capture.
+			Class.prototype.attributeChangedCallback = function (name, value) {
+				this.constructor.props.attributeChanged(this, name, value);
+			};
+		}
 
-		// Snapshot observedAttributes once at registration, like customElements.define.
-		Class[defined] = plugins.length ? Class.observedAttributes : Class.props.observedAttributes;
+		// Snapshot at registration, like customElements.define builds a CustomElementDefinition.
+		Class[definition] = {
+			observedAttributes: plugins.length
+				? Class.observedAttributes
+				: Class.props.observedAttributes,
+			attributeChangedCallback: Class.prototype.attributeChangedCallback,
+		};
 
 		return Class;
 	}


### PR DESCRIPTION
## TL;DR

Calling `el.setAttribute("v", "100")` after mount on a `reflect: true` prop did not update `el.v`, because `customElements.define` cached an empty `observedAttributes` list and a `null` `attributeChangedCallback` at registration time. This PR makes ACB always present on the prototype chain via the props plugin's `provides`, which lets the spec read `observedAttributes` and triggers the eager static getter that populates it.

## Why

Per [HTML spec §CustomElementRegistry.define](https://html.spec.whatwg.org/multipage/custom-elements.html#element-definition):

1. For each lifecycle-callback name, `? Get(prototype, callbackName)`.
2. `observedAttributes` is initialized to an empty sequence.
3. **Only if `lifecycleCallbacks["attributeChangedCallback"]` is non-null**, `? Get(constructor, "observedAttributes")`.

Pre-this-PR, `attributeChangedCallback` was wired inside `first_constructor_static` (which fires on first instance construction, after registration). The browser snapshotted a `null` ACB at `define` time and so never read `observedAttributes` either. Pre-set attributes worked only because `Props.initializeFor` re-walks `observedAttributes` on mount.

The natural fix is to make sure ACB is reachable through the prototype chain by the time `customElements.define` runs.

## What

### `src/plugins/props/index.js`

`attributeChangedCallback` becomes a regular entry in the plugin's `provides`. `addPlugins` lands it on `NudeElement.prototype` once, and every subclass — at any depth of inheritance — inherits it through the chain. So `Get(Class.prototype, "attributeChangedCallback")` returns it during `define`, which causes the spec to read `Class.observedAttributes`, which triggers the eager static getter and populates the cache.

Chaining to a user-declared override follows the same pattern as `connectedCallback` in [src/element/members.js](src/element/members.js): `getSuperMethod(this, provides.attributeChangedCallback)?.call(this, ...)` then the plugin's dispatch into `Props.attributeChanged`. A subclass that overrides `attributeChangedCallback` must call `super.attributeChangedCallback(...)` to compose, which is standard JS — see "Known caveat" below.

The eager static `observedAttributes` getter on `providesStatic` is kept — its only job now is to lazily call `defineProps()` and return the list. The previous ACB install block inside the getter is gone (it was the chicken-and-egg: ACB-on-prototype is the precondition for the getter ever firing).

The cache is still reserved as `[]` **before** `defineProps` runs, so a `define-props` hook that reads `Class.observedAttributes` hits the cache instead of recursing — same re-entry-guard shape as `attachShadow` in [src/plugins/shadow/index.js](src/plugins/shadow/index.js).

The props plugin's `setup` hook still skips `defineProps()` when the static getter has already cached `observedAttributes`, so plugin-contributed additive calls (e.g. `events/onprops` appending synthetic `on*` props via `this.defineProps(newProps)`) keep working after the static install.

### `test/util/FakeElement.js`

`FakeElement.with` now mirrors the spec faithfully when building its per-class `CustomElementDefinition`-shaped snapshot:

1. Read `attributeChangedCallback` from the prototype chain first.
2. **Only if non-null**, read `observedAttributes` from the constructor.

This closes the loophole the previous test harness had: it used to read `Class.observedAttributes` unconditionally, which triggered the eager install regardless of whether ACB was actually on the prototype — making the unit test pass even when the real-browser path was broken (the central complaint of the PR review). With this conditional, the unit suite is now load-bearing on the spec path.

The snapshot logic was also extracted into a new `FakeElement.define(Class)` static method, so a test can swap a class's prototype ACB and re-snapshot — modelling how `customElements.define` snapshots each registered class independently. Used by the subclass-override regression test below.

`setAttribute` / `removeAttribute` continue to dispatch through the snapshot, the same path a real browser takes via `lifecycleCallbacks`.

### `test/Props.js`

The existing `"Post-mount setAttribute updates the property"` test now exercises the real registration path end-to-end. Without `provides.attributeChangedCallback`, it fails with `Got undefined, expected 100` — the literal symptom from #98.

The `Class.defineProps()` additive-contract test (added in an earlier commit on this branch) still pins down that `defineProps({ bar: {} })` after the registration-time install must still register `bar`.

A new `Subclass attributeChangedCallback override` group pins both halves of the new contract (see "Known caveat" below):

- **Override that calls super updates the reflected prop** (expect `100`) — verifies that chaining via `super.attributeChangedCallback(...)` still flows through `Props.attributeChanged`.
- **Override that omits super leaves the reflected prop unchanged** (expect `undefined`) — verifies that forgetting `super` does silently drop the reflection, so the contract is observable in tests.

Both halves were sanity-checked: inverting either branch causes exactly the opposite test to fail with the expected symptom.

## Known caveat — behavior change vs pre-PR-109

Pre-PR-109, `first_constructor_static` unconditionally wrapped any existing ACB on the prototype chain. A subclass could declare its own `attributeChangedCallback` and **still** get the plugin's reflected-prop dispatch fired automatically, without calling super. PR-109 partially broke that auto-wrap (its `!Object.hasOwn(this.prototype, "attributeChangedCallback")` guard skipped wrapping for any subclass that had an own ACB). This PR drops the auto-wrap entirely.

**The new contract**: any subclass that overrides `attributeChangedCallback` must call `super.attributeChangedCallback(name, oldValue, value)` to compose with the plugin. The same convention already governs `connectedCallback` / `disconnectedCallback` in this codebase. Pinned by the new regression test in `test/Props.js`.

**Why auto-wrap can't be restored without an API change.** JavaScript class-method syntax installs a data property on the subclass prototype via internal `DefineOwnProperty` — that path bypasses any setter trap we could install on the base prototype, so there is no language-level way to intercept "subclass just defined an ACB" without consumer cooperation. The spec snapshots ACB at `customElements.define` time and never looks at the prototype again, so wrapping later (eager getter, first construction, etc.) is invisible to the cached callback. The pre-PR-109 wrapping landed at first construction — which is precisely why the spec snapshot was already cached (with `null`) by then, i.e. the auto-wrap *was* the bug. You can have auto-wrap or spec-correct registration, not both, without introducing a `NudeElement.define(name)` registration helper.

**Footgun severity.** This is the worst lifecycle hook to require manual super-chaining on, from a footgun-cost perspective: forgetting `super` silently re-introduces #98 for that one subclass. By contrast, forgetting `super.connectedCallback?.()` only breaks the `connected` hook (propchange queue drain on reconnect — obscure). A registration helper that would restore auto-wrap without re-introducing the spec problem is proposed for discussion in #110.

## Out of scope

- `// FIXME how to combine with existing observedAttributes?` ([src/plugins/props/index.js](src/plugins/props/index.js)) — preserved. Merging a user-declared `static observedAttributes` with derived ones is an open question; current shadowing semantics are kept.
- ACB inheritance edge cases — tracked separately under #104.
- A registration helper (`NudeElement.define(name)`) that auto-wraps lifecycle callbacks uniformly — not introduced here. Proposed for discussion in #110.

## Test plan

- [x] `npm test` — 102/103 pass (1 pre-existing skip in `split()`).
- [x] Negative control: commenting out the new `provides.attributeChangedCallback` → `"Post-mount setAttribute updates the property"` fails with `Got undefined, expected 100`, proving the prototype-resident ACB is what enables the spec path.
- [x] Negative control: removing the `acb ?` conditional in `FakeElement.with` → tests still pass but the harness stops mirroring the spec; confirms the conditional itself is load-bearing on the regression check.
- [x] Negative control on the new override-contract test: unconditionally chaining to super → `"Override that omits super leaves the reflected prop unchanged"` fails with `Got 100, expected undefined`; never chaining → `"Override that calls super updates the reflected prop"` fails with `Got undefined, expected 100`. Both halves are load-bearing.
- [x] Real-browser spot check (manual): in the deploy preview, on `<color-picker>` (which inherits two levels — `ColorPicker → ColorElement → NudeElement`), call `setAttribute` on a reflected prop from DevTools and confirm the JS property updates.
