### PR TITLE
Fire propchange synchronously, batch only propschange (closes #111)

### DIFF
--- a/src/plugins/props/README.md
+++ b/src/plugins/props/README.md
@@ -225,3 +225,9 @@ Attribute reflection is synchronous with property writes. Within a tick:
 2. **`propschange` event** + `updated()` callback fire once at end-of-tick, on the next microtask, with the full Map of every prop that changed across all sync writes in that tick.
 
 Net no-ops (a prop set away and back to its first-seen value within the tick) are dropped from step 2 but still produce step 1 events, the same way assigning to a native IDL property always fires the property setter even when the result is unchanged.
+
+### Disconnected elements (pause / resume)
+
+Change monitoring is **paused** while an element is disconnected and **resumed** on reconnect. Writes still land (signals update, Computeds recompute, reads stay consistent) — but both `propchange` and `propschange` dispatch is held until the element rejoins the DOM. On resume, each changed prop fires one coalesced `propchange` (`oldValue` pinned to the value before pause, `value` the current state), followed by one `propschange` covering the full delta.
+
+This is exposed as `props.pause(element)` / `props.resume(element)` so consumers can also batch a burst of writes manually — the `disconnectedCallback` / `connectedCallback` lifecycle hooks just wire to them.

--- a/src/plugins/props/README.md
+++ b/src/plugins/props/README.md
@@ -175,7 +175,9 @@ There are two layers of observability for prop changes, both first-class:
 | Per prop         | `propchange`  | `propChangedCallback(event)` |
 | Per drain (bulk) | `propschange` | `updated(event)`             |
 
-Sync writes are coalesced into a single drain on the next microtask, so `el.x = 1; el.x = 2; el.x = 3` produces one `propchange` event with `value: 3`. `oldValue` is pinned to the pre-write value, so the event reports the full first→last delta.
+`propchange` events fire **synchronously** per write — `el.x = 1; el.x = 2; el.x = 3` produces three events, matching native IDL property semantics. Computed dependents settle before the originator's event fires, so handlers see post-cascade values via `this[name]`.
+
+Coalescing belongs to the per-drain tier: `propschange` and `updated()` fire once at end-of-tick (next microtask), summarizing the full delta across every sync write that happened in that tick. `oldValue` is pinned to the first-seen value, so a round-trip back to that value (e.g. `el.x = 5; el.x = 0` when `x` started at `0`) is dropped from the summary entirely.
 
 ### Per-prop: `propchange` event and `propChangedCallback`
 
@@ -217,9 +219,9 @@ Use this for work you only want to run once per cycle (re-rendering a sub-tree, 
 
 ### Cycle ordering
 
-Attribute reflection is synchronous with property writes, so the DOM is up to date before the drain runs. Within a single drain:
+Attribute reflection is synchronous with property writes. Within a tick:
 
-1. **`propchange` events** — one per changed prop. Custom shortcut events (registered via the `events` plugin's `propchange:` option) also fire here from the same payload.
-2. **`propschange` event** + `updated()` callback — last, with the full Map.
+1. **`propchange` events** fire synchronously per write, after every transitive Computed has settled — handlers always see post-cascade values via `this[name]`. Custom shortcut events (registered via the `events` plugin's `propchange:` option) fire from the same payload.
+2. **`propschange` event** + `updated()` callback fire once at end-of-tick, on the next microtask, with the full Map of every prop that changed across all sync writes in that tick.
 
-Handlers in step 2 see the fully-settled state and can read any prop's post-cascade value via `this[name]`.
+Net no-ops (a prop set away and back to its first-seen value within the tick) are dropped from step 2 but still produce step 1 events, the same way assigning to a native IDL property always fires the property setter even when the result is unchanged.

--- a/src/plugins/props/index.js
+++ b/src/plugins/props/index.js
@@ -54,6 +54,10 @@ const hooks = {
 	connected () {
 		this.constructor[props].connected(this);
 	},
+
+	disconnected () {
+		this.constructor[props].disconnected(this);
+	},
 };
 
 const provides = {

--- a/src/plugins/props/util/Prop.js
+++ b/src/plugins/props/util/Prop.js
@@ -240,7 +240,7 @@ let Self = class Prop {
 				// Sync drain at the end of the user-visible write: every
 				// transitive Computed has settled at this point, so handlers
 				// see post-cascade values.
-				me.props.drain();
+				me.props.drain(this);
 			};
 		}
 		else if (this.spec.set) {

--- a/src/plugins/props/util/Prop.js
+++ b/src/plugins/props/util/Prop.js
@@ -237,6 +237,10 @@ let Self = class Prop {
 		if (!this.spec.get || this.spec.set === true) {
 			descriptor.set = function (value) {
 				me.set(this, value, { source: "property" });
+				// Sync drain at the end of the user-visible write: every
+				// transitive Computed has settled at this point, so handlers
+				// see post-cascade values.
+				me.props.drain();
 			};
 		}
 		else if (this.spec.set) {
@@ -366,7 +370,7 @@ let Self = class Prop {
 		}
 	}
 
-	async changed (element, change) {
+	changed (element, change) {
 		this.spec.changed?.call(element, change);
 		this.props.propChanged(element, this, change);
 	}

--- a/src/plugins/props/util/Props.js
+++ b/src/plugins/props/util/Props.js
@@ -4,27 +4,33 @@ import PropsChangeEvent from "./PropsChangeEvent.js";
 
 export default class Props extends Map {
 	/**
-	 * Per-element coalescing buffer. Sync writes to the same prop overwrite the entry's
-	 * `value`/`source` (latest wins) while pinning `oldValue`/`oldAttributeValue` to the
-	 * first write — so the drained payload spans the full first→last delta. Drained and
-	 * cleared in `#drainFor`.
-	 * @type {WeakMap<HTMLElement, Map<string, {name: string, prop: Prop, detail: object}>>}
+	 * Per-element propchange events buffered between `propChanged` and the
+	 * synchronous drain at end of the originating write. Buffering — not
+	 * coalescing — lets all transitive Computeds settle before the first
+	 * propchange fires, so handlers see post-cascade values via `this[name]`.
+	 * @type {WeakMap<HTMLElement, Array<{name: string, prop: Prop, detail: object}>>}
 	 */
-	#eventDispatchQueue = new WeakMap();
+	#propchangeQueue = new WeakMap();
+
+	/** @type {Set<HTMLElement>} Elements with a pending sync drain. */
+	#pendingPropchangeElements = new Set();
+
+	/** Re-entrancy guard: nested `drain` calls are absorbed by the outer. */
+	#drainInProgress = false;
 
 	/**
-	 * Elements with queued events awaiting drain. Snapshotted and cleared at the top of
-	 * `#drain` so re-entrant writes (from handlers) accumulate for the *next* drain.
-	 * @type {Set<HTMLElement>}
+	 * Per-element propschange accumulator. Maps prop name → first-seen
+	 * oldValue, pinned across all sync writes in the current tick so the
+	 * dispatched payload spans a tick-wide first→last delta.
+	 * @type {WeakMap<HTMLElement, Map<string, *>>}
 	 */
-	#pendingElements = new Set();
+	#pendingChangedProps = new WeakMap();
 
-	/**
-	 * Microtask-schedule guard. Set when a drain is queued, cleared when it runs —
-	 * collapses many `propChanged` calls in the same tick into one `queueMicrotask`.
-	 * @type {boolean}
-	 */
-	#drainScheduled = false;
+	/** @type {Set<HTMLElement>} Elements with a pending propschange dispatch. */
+	#pendingPropschangeElements = new Set();
+
+	/** Microtask-schedule guard for the propschange drain. */
+	#propschangeScheduled = false;
 
 	/**
 	 *
@@ -76,88 +82,127 @@ export default class Props extends Map {
 				oldAttributeValue: oldValue,
 			});
 		}
+
+		this.drain();
 	}
 
 	/**
-	 * Called from Prop#changed when a value settles. Coalesces into the
-	 * dispatch queue; dispatch happens in #drainFor on the next microtask.
+	 * Called from `Prop#changed` when a value settles. Queues the per-prop
+	 * `propchange` payload for synchronous drain at end of the originating
+	 * write, and accumulates into the per-tick `propschange` summary
+	 * (drained on a microtask).
 	 */
 	propChanged (element, prop, change) {
-		let map = this.#eventDispatchQueue.get(element);
+		let queue = this.#propchangeQueue.get(element);
+		if (!queue) {
+			queue = [];
+			this.#propchangeQueue.set(element, queue);
+		}
+		queue.push({ name: prop.name, prop, detail: change });
+		this.#pendingPropchangeElements.add(element);
+
+		let map = this.#pendingChangedProps.get(element);
 		if (!map) {
 			map = new Map();
-			this.#eventDispatchQueue.set(element, map);
+			this.#pendingChangedProps.set(element, map);
 		}
-
-		let existing = map.get(prop.name);
-		if (existing) {
-			// Coalesce: latest value/source wins, but old values stay pinned
-			// to the first write so the payload spans the full first→last delta.
-			let { oldValue, oldAttributeValue } = existing.detail;
-			Object.assign(existing.detail, change, { oldValue, oldAttributeValue });
+		// First-seen oldValue wins so propschange covers the full tick-wide
+		// delta even across coalesced sync writes.
+		if (!map.has(prop.name)) {
+			map.set(prop.name, change.oldValue);
 		}
-		else {
-			map.set(prop.name, { name: prop.name, prop, detail: { ...change } });
-		}
-
-		this.#pendingElements.add(element);
-		this.#scheduleDrain();
+		this.#pendingPropschangeElements.add(element);
+		this.#schedulePropschange();
 	}
 
-	#scheduleDrain () {
-		if (this.#drainScheduled) {
+	/**
+	 * Synchronously dispatch all queued `propchange` events for connected
+	 * elements. Re-entrant calls (from inside a propchange handler) are
+	 * absorbed by the outer drain, which keeps looping until handlers stop
+	 * queuing new events.
+	 */
+	drain () {
+		if (this.#drainInProgress) {
 			return;
 		}
 
-		this.#drainScheduled = true;
+		this.#drainInProgress = true;
+		try {
+			while (this.#pendingPropchangeElements.size > 0) {
+				let pending = [...this.#pendingPropchangeElements];
+				this.#pendingPropchangeElements.clear();
+				for (let element of pending) {
+					if (element.isConnected) {
+						this.#dispatchPropchanges(element);
+					}
+					// Disconnected: leave queue intact for `connected()` to drain on reconnect.
+				}
+			}
+		}
+		finally {
+			this.#drainInProgress = false;
+		}
+	}
+
+	#dispatchPropchanges (element) {
+		let queue = this.#propchangeQueue.get(element);
+		if (!queue) {
+			return;
+		}
+
+		// Detach before dispatch so re-entrant writes from handlers land
+		// in a fresh queue and surface on the next drain iteration.
+		this.#propchangeQueue.delete(element);
+
+		for (let payload of queue) {
+			// EventTarget isolates listener throws — siblings stay safe without try/catch.
+			for (let name of ["propchange", ...(payload.prop.eventNames ?? [])]) {
+				element.dispatchEvent(new PropChangeEvent(name, payload));
+			}
+		}
+	}
+
+	#schedulePropschange () {
+		if (this.#propschangeScheduled) {
+			return;
+		}
+		this.#propschangeScheduled = true;
 		queueMicrotask(() => {
-			this.#drainScheduled = false;
-			this.#drain();
+			this.#propschangeScheduled = false;
+			this.#drainPropschange();
 		});
 	}
 
-	#drain () {
-		// Snapshot and clear: events queued by handlers (incl. on other
-		// elements) run on the next microtask, not in this drain.
-		let elements = [...this.#pendingElements];
-		this.#pendingElements.clear();
-
-		for (let element of elements) {
-			this.#drainFor(element);
+	#drainPropschange () {
+		let pending = [...this.#pendingPropschangeElements];
+		this.#pendingPropschangeElements.clear();
+		for (let element of pending) {
+			this.#dispatchPropschangeFor(element);
 		}
 	}
 
-	#drainFor (element) {
+	#dispatchPropschangeFor (element) {
 		if (!element.isConnected) {
-			// Queue stays intact; `connected()` drains it on (re)connect.
+			// Leave the accumulator intact. Don't re-add to pending — that
+			// would pin a strong reference to a disconnected element.
+			// `connected()` checks `#pendingChangedProps` directly on reconnect.
 			return;
 		}
 
-		let map = this.#eventDispatchQueue.get(element);
+		let map = this.#pendingChangedProps.get(element);
 		if (!map) {
 			return;
 		}
-
-		// Detach the queue before dispatch: re-entrant writes from event
-		// handlers must accumulate for the next drain, not this one.
-		let entries = [...map];
-		this.#eventDispatchQueue.delete(element);
+		this.#pendingChangedProps.delete(element);
 
 		let changedProps = new Map();
-		for (let [, payload] of entries) {
-			// Plain Signals don't dedupe coalesced round-trips on their own;
-			// mirror Signal equality here.
-			let { prop, detail } = payload;
-			if (prop.equals(detail.value, detail.oldValue)) {
+		for (let [name, oldValue] of map) {
+			let prop = this.get(name);
+			// Skip round-trips: prop is back at its first-seen old value, net no-op.
+			if (prop && prop.equals(element[name], oldValue)) {
 				continue;
 			}
-
-			changedProps.set(prop.name, detail.oldValue);
-
-			// EventTarget isolates listener throws — siblings stay safe without try/catch.
-			for (let name of ["propchange", ...(prop.eventNames ?? [])]) {
-				element.dispatchEvent(new PropChangeEvent(name, payload));
-			}
+			changedProps.set(name, oldValue);
 		}
 
 		if (changedProps.size > 0) {
@@ -166,7 +211,19 @@ export default class Props extends Map {
 	}
 
 	connected (element) {
-		this.#drainFor(element);
+		// Drain any propchange events that landed while disconnected.
+		if (this.#propchangeQueue.has(element)) {
+			this.#dispatchPropchanges(element);
+			this.#pendingPropchangeElements.delete(element);
+		}
+		// Fire any pending propschange summary now that the element is observable.
+		// Pull from the per-element accumulator directly — the element may not be
+		// in `#pendingPropschangeElements` if the deferred microtask already saw
+		// it disconnected and skipped without re-adding.
+		if (this.#pendingChangedProps.has(element)) {
+			this.#pendingPropschangeElements.delete(element);
+			this.#dispatchPropschangeFor(element);
+		}
 	}
 
 	initializeFor (element) {
@@ -185,7 +242,9 @@ export default class Props extends Map {
 			prop.initializeFor(element);
 		}
 
-		// Drain synchronously so callers see initial state without waiting for the microtask.
-		this.#drainFor(element);
+		// Mount is a discrete event — drain both tiers synchronously so
+		// callers see the settled initial state without an extra await.
+		this.drain();
+		this.#dispatchPropschangeFor(element);
 	}
 }

--- a/src/plugins/props/util/Props.js
+++ b/src/plugins/props/util/Props.js
@@ -4,13 +4,25 @@ import PropsChangeEvent from "./PropsChangeEvent.js";
 
 export default class Props extends Map {
 	/**
-	 * Per-element propchange events buffered between `propChanged` and the
-	 * synchronous drain at end of the originating write. Buffering — not
-	 * coalescing — lets all transitive Computeds settle before the first
-	 * propchange fires, so handlers see post-cascade values via `this[name]`.
-	 * @type {WeakMap<HTMLElement, Array<{name: string, prop: Prop, detail: object}>>}
+	 * Per-element coalescing buffer: prop name → payload with the latest
+	 * value/source and the first-seen oldValue. While the element is active
+	 * (default), `drain` empties the queue immediately after the originating
+	 * write so handlers see one propchange per prop with post-cascade values.
+	 * While the element is paused (e.g. disconnected), writes accumulate so
+	 * resume dispatches one coalesced event per prop, with `oldValue` pinned
+	 * to the value before pause and `value` the final post-resume state.
+	 * @type {WeakMap<HTMLElement, Map<string, {name: string, prop: Prop, detail: object}>>}
 	 */
 	#propchangeQueue = new WeakMap();
+
+	/**
+	 * Elements with change monitoring paused — propchange/propschange
+	 * dispatch is held until `resume`. Lifecycle wires `disconnected` →
+	 * `pause` and `connected` → `resume` so writes while detached coalesce
+	 * into a single per-prop event on reconnect.
+	 * @type {WeakSet<HTMLElement>}
+	 */
+	#paused = new WeakSet();
 
 	/**
 	 * Per-element re-entrancy guard for `drain`. Nested writes on the same
@@ -23,8 +35,8 @@ export default class Props extends Map {
 
 	/**
 	 * Per-element propschange accumulator. Maps prop name → first-seen
-	 * oldValue, pinned across all sync writes in the current tick so the
-	 * dispatched payload spans a tick-wide first→last delta.
+	 * oldValue, pinned across all sync writes in the current tick (or pause
+	 * period) so the dispatched payload spans the full delta.
 	 * @type {WeakMap<HTMLElement, Map<string, *>>}
 	 */
 	#pendingChangedProps = new WeakMap();
@@ -90,26 +102,39 @@ export default class Props extends Map {
 	}
 
 	/**
-	 * Called from `Prop#changed` when a value settles. Queues the per-prop
-	 * `propchange` payload for synchronous drain at end of the originating
-	 * write, and accumulates into the per-tick `propschange` summary
-	 * (drained on a microtask).
+	 * Called from `Prop#changed` when a value settles. Coalesces into the
+	 * per-element propchange queue (latest value/source wins, oldValue
+	 * pinned to first-seen) and accumulates into the propschange summary.
+	 * For active elements, `drain` runs after the originating write and
+	 * dispatches before the next write can queue, so each write fires its
+	 * own event; for paused elements, writes coalesce until `resume`.
 	 */
 	propChanged (element, prop, change) {
 		let queue = this.#propchangeQueue.get(element);
 		if (!queue) {
-			queue = [];
+			queue = new Map();
 			this.#propchangeQueue.set(element, queue);
 		}
-		queue.push({ name: prop.name, prop, detail: change });
+		let existing = queue.get(prop.name);
+		if (existing) {
+			// Coalesce. Pin oldValue (and oldAttributeValue, if any) to the
+			// first-seen pre-write value so the dispatched payload spans the
+			// full first→last delta.
+			let { oldValue, oldAttributeValue } = existing.detail;
+			existing.detail = { ...change, oldValue };
+			if (oldAttributeValue !== undefined) {
+				existing.detail.oldAttributeValue = oldAttributeValue;
+			}
+		}
+		else {
+			queue.set(prop.name, { name: prop.name, prop, detail: { ...change } });
+		}
 
 		let map = this.#pendingChangedProps.get(element);
 		if (!map) {
 			map = new Map();
 			this.#pendingChangedProps.set(element, map);
 		}
-		// First-seen oldValue wins so propschange covers the full tick-wide
-		// delta even across coalesced sync writes.
 		if (!map.has(prop.name)) {
 			map.set(prop.name, change.oldValue);
 		}
@@ -121,19 +146,18 @@ export default class Props extends Map {
 	 * Synchronously dispatch this element's queued `propchange` events.
 	 * Loops until the queue is empty so re-entrant writes from handlers
 	 * surface in the same drain. Nested calls *on the same element* are
-	 * no-ops; nested calls on a different element get their own drain.
+	 * no-ops. Paused elements skip entirely — `resume` will dispatch later.
 	 */
 	drain (element) {
-		if (this.#draining.has(element)) {
+		if (this.#draining.has(element) || this.#paused.has(element)) {
 			return;
 		}
 
 		this.#draining.add(element);
 		try {
-			while (element.isConnected && this.#propchangeQueue.has(element)) {
+			while (this.#propchangeQueue.has(element)) {
 				this.#dispatchPropchanges(element);
 			}
-			// Disconnected: leave queue intact; `connected()` drains on reconnect.
 		}
 		finally {
 			this.#draining.delete(element);
@@ -150,9 +174,15 @@ export default class Props extends Map {
 		// in a fresh queue and surface on the next drain iteration.
 		this.#propchangeQueue.delete(element);
 
-		for (let payload of queue) {
+		for (let payload of queue.values()) {
+			let { prop, detail } = payload;
+			// Skip net no-ops — only possible when coalescing collapsed a
+			// round-trip back to the first-seen value (e.g. while paused).
+			if (prop.equals(detail.value, detail.oldValue)) {
+				continue;
+			}
 			// EventTarget isolates listener throws — siblings stay safe without try/catch.
-			for (let name of ["propchange", ...(payload.prop.eventNames ?? [])]) {
+			for (let name of ["propchange", ...(prop.eventNames ?? [])]) {
 				element.dispatchEvent(new PropChangeEvent(name, payload));
 			}
 		}
@@ -178,10 +208,10 @@ export default class Props extends Map {
 	}
 
 	#dispatchPropschangeFor (element) {
-		if (!element.isConnected) {
+		if (this.#paused.has(element)) {
 			// Leave the accumulator intact. Don't re-add to pending — that
-			// would pin a strong reference to a disconnected element.
-			// `connected()` checks `#pendingChangedProps` directly on reconnect.
+			// would pin a strong reference to a detached element.
+			// `resume()` checks `#pendingChangedProps` directly.
 			return;
 		}
 
@@ -206,17 +236,36 @@ export default class Props extends Map {
 		}
 	}
 
-	connected (element) {
-		// Drain any propchange events that landed while disconnected.
+	/**
+	 * Hold propchange/propschange dispatch for this element. Writes still
+	 * land (signals update, Computeds recompute, reads stay consistent),
+	 * but events coalesce into the per-element queue and accumulator
+	 * instead of firing. Resume drains both as one settled snapshot.
+	 */
+	pause (element) {
+		this.#paused.add(element);
+	}
+
+	/**
+	 * Resume change monitoring and drain anything that accumulated while
+	 * paused: one coalesced propchange per changed prop, then the
+	 * propschange summary.
+	 */
+	resume (element) {
+		this.#paused.delete(element);
 		this.drain(element);
-		// Fire any pending propschange summary now that the element is observable.
-		// Pull from the per-element accumulator directly — the element may not be
-		// in `#pendingPropschangeElements` if the deferred microtask already saw
-		// it disconnected and skipped without re-adding.
 		if (this.#pendingChangedProps.has(element)) {
 			this.#pendingPropschangeElements.delete(element);
 			this.#dispatchPropschangeFor(element);
 		}
+	}
+
+	connected (element) {
+		this.resume(element);
+	}
+
+	disconnected (element) {
+		this.pause(element);
 	}
 
 	initializeFor (element) {

--- a/src/plugins/props/util/Props.js
+++ b/src/plugins/props/util/Props.js
@@ -12,11 +12,14 @@ export default class Props extends Map {
 	 */
 	#propchangeQueue = new WeakMap();
 
-	/** @type {Set<HTMLElement>} Elements with a pending sync drain. */
-	#pendingPropchangeElements = new Set();
-
-	/** Re-entrancy guard: nested `drain` calls are absorbed by the outer. */
-	#drainInProgress = false;
+	/**
+	 * Per-element re-entrancy guard for `drain`. Nested writes on the same
+	 * element (e.g. a propchange handler that writes back to its own prop)
+	 * fall back to the outer drain; writes on a *different* element get
+	 * their own drain, since their cascade and queue are independent.
+	 * @type {WeakSet<HTMLElement>}
+	 */
+	#draining = new WeakSet();
 
 	/**
 	 * Per-element propschange accumulator. Maps prop name → first-seen
@@ -83,7 +86,7 @@ export default class Props extends Map {
 			});
 		}
 
-		this.drain();
+		this.drain(element);
 	}
 
 	/**
@@ -99,7 +102,6 @@ export default class Props extends Map {
 			this.#propchangeQueue.set(element, queue);
 		}
 		queue.push({ name: prop.name, prop, detail: change });
-		this.#pendingPropchangeElements.add(element);
 
 		let map = this.#pendingChangedProps.get(element);
 		if (!map) {
@@ -116,31 +118,25 @@ export default class Props extends Map {
 	}
 
 	/**
-	 * Synchronously dispatch all queued `propchange` events for connected
-	 * elements. Re-entrant calls (from inside a propchange handler) are
-	 * absorbed by the outer drain, which keeps looping until handlers stop
-	 * queuing new events.
+	 * Synchronously dispatch this element's queued `propchange` events.
+	 * Loops until the queue is empty so re-entrant writes from handlers
+	 * surface in the same drain. Nested calls *on the same element* are
+	 * no-ops; nested calls on a different element get their own drain.
 	 */
-	drain () {
-		if (this.#drainInProgress) {
+	drain (element) {
+		if (this.#draining.has(element)) {
 			return;
 		}
 
-		this.#drainInProgress = true;
+		this.#draining.add(element);
 		try {
-			while (this.#pendingPropchangeElements.size > 0) {
-				let pending = [...this.#pendingPropchangeElements];
-				this.#pendingPropchangeElements.clear();
-				for (let element of pending) {
-					if (element.isConnected) {
-						this.#dispatchPropchanges(element);
-					}
-					// Disconnected: leave queue intact for `connected()` to drain on reconnect.
-				}
+			while (element.isConnected && this.#propchangeQueue.has(element)) {
+				this.#dispatchPropchanges(element);
 			}
+			// Disconnected: leave queue intact; `connected()` drains on reconnect.
 		}
 		finally {
-			this.#drainInProgress = false;
+			this.#draining.delete(element);
 		}
 	}
 
@@ -212,10 +208,7 @@ export default class Props extends Map {
 
 	connected (element) {
 		// Drain any propchange events that landed while disconnected.
-		if (this.#propchangeQueue.has(element)) {
-			this.#dispatchPropchanges(element);
-			this.#pendingPropchangeElements.delete(element);
-		}
+		this.drain(element);
 		// Fire any pending propschange summary now that the element is observable.
 		// Pull from the per-element accumulator directly — the element may not be
 		// in `#pendingPropschangeElements` if the deferred microtask already saw
@@ -244,7 +237,7 @@ export default class Props extends Map {
 
 		// Mount is a discrete event — drain both tiers synchronously so
 		// callers see the settled initial state without an extra await.
-		this.drain();
+		this.drain(element);
 		this.#dispatchPropschangeFor(element);
 	}
 }

--- a/src/signals.js
+++ b/src/signals.js
@@ -8,35 +8,40 @@ let tracking = null;
 
 /** @type {Set<Computed>} Computeds marked dirty, awaiting recomputation */
 let dirtyComputeds = new Set();
-let flushScheduled = false;
 
-/**
- * Schedule a microtask to recompute all dirty Computeds.
- * Uses a while-loop to handle cascades (computing B may dirty D).
- */
-function scheduleDirtyFlush () {
-	if (!flushScheduled) {
-		flushScheduled = true;
-		queueMicrotask(flushDirty);
-	}
-}
+/** Re-entrancy guard for `flushDirty`. Nested calls are absorbed by the outer one. */
+let flushing = false;
 
 const MAX_FLUSH_ITERATIONS = 100;
 
+/**
+ * Synchronously recompute all dirty Computeds in topological order.
+ * The outermost call drains any Computeds newly dirtied during the flush —
+ * nested calls (from Signal writes inside a subscriber) are no-ops.
+ */
 function flushDirty () {
-	flushScheduled = false;
-	let iterations = 0;
-	while (dirtyComputeds.size > 0) {
-		if (++iterations > MAX_FLUSH_ITERATIONS) {
-			console.warn("Signals: possible circular dependency detected, aborting flush after", MAX_FLUSH_ITERATIONS, "iterations");
+	if (flushing) {
+		return;
+	}
+
+	flushing = true;
+	try {
+		let iterations = 0;
+		while (dirtyComputeds.size > 0) {
+			if (++iterations > MAX_FLUSH_ITERATIONS) {
+				console.warn("Signals: possible circular dependency detected, aborting flush after", MAX_FLUSH_ITERATIONS, "iterations");
+				dirtyComputeds.clear();
+				break;
+			}
+			let batch = [...dirtyComputeds];
 			dirtyComputeds.clear();
-			break;
+			for (let computed of batch) {
+				computed.recomputeIfDirty();
+			}
 		}
-		let batch = [...dirtyComputeds];
-		dirtyComputeds.clear();
-		for (let computed of batch) {
-			computed.recomputeIfDirty();
-		}
+	}
+	finally {
+		flushing = false;
 	}
 }
 
@@ -75,6 +80,10 @@ export class Signal extends EventTarget {
 		let old = this.#value;
 		this.#value = v;
 		this.#notify(old);
+		// Drain any Computeds the notify just marked dirty. Sync flush keeps
+		// reads, propchange dispatch, and dependent recomputation all on the
+		// same tick as the originating write.
+		flushDirty();
 	}
 
 	/**
@@ -139,8 +148,8 @@ export class Computed extends Signal {
 	}
 
 	/**
-	 * Recompute if dirty. Called by the batch flush scheduler
-	 * and also available for eager evaluation.
+	 * Recompute if dirty. Called from the topological flush loop and also
+	 * available for eager evaluation when a reader reaches a dirty Computed.
 	 */
 	recomputeIfDirty () {
 		if (this.#dirty) {
@@ -177,13 +186,14 @@ export class Computed extends Signal {
 		this.#deps = deps;
 		this.#dirty = false;
 
-		// Subscribe to all discovered deps — mark dirty and schedule,
-		// don't recompute immediately (avoids glitches in diamond deps)
+		// Subscribe to all discovered deps. The subscriber just marks dirty
+		// and joins the flush set — the outer `flushDirty` (running because
+		// it was kicked off by the originating `Signal.value` write) sees
+		// the new entry on its next iteration and recomputes in order.
 		for (let dep of this.#deps) {
 			this.#unsubs.push(dep.subscribe(() => {
 				this.#dirty = true;
 				dirtyComputeds.add(this);
-				scheduleDirtyFlush();
 			}));
 		}
 

--- a/test/Prop.js
+++ b/test/Prop.js
@@ -394,7 +394,17 @@ export default {
 							expect: ["v/default"],
 						},
 						{
-							name: "Sync writes to a plain Signal coalesce to a single event with the settled value",
+							name: "Each sync write to a plain Signal fires its own propchange",
+							async run ({ props, actions = [], only }) {
+								let el = new (FakeElement.with(props))();
+								let events = [];
+								el.addEventListener("propchange", e =>
+									events.push({ name: e.name, source: e.detail?.source }));
+								el.mount();
+								await apply(el, actions);
+								let stream = only ? events.filter(e => only.includes(e.name)) : events;
+								return stream.length;
+							},
 							arg: {
 								props: { v: { type: Number } },
 								actions: [
@@ -406,11 +416,13 @@ export default {
 								],
 								only: ["v"],
 							},
-							// No mount event: plain Signal initial undefined ≡ oldValue.
-							expect: ["v/property"],
+							// No mount event (plain Signal initial undefined ≡ oldValue).
+							// Three writes → three propchange events; coalescing belongs
+							// to propschange / updated() (covered in `updated() bulk semantics`).
+							expect: 3,
 						},
 						{
-							name: "Round-trip back to the initial value on a plain Signal fires no event",
+							name: "Round-trip back to the initial value fires propchange for each write",
 							async run ({ props, actions }) {
 								let el = new (FakeElement.with(props))();
 								let count = 0;
@@ -428,7 +440,9 @@ export default {
 									},
 								],
 							},
-							expect: 0,
+							// Net no-op is dropped by `propschange` (see corresponding
+							// test in `updated() bulk semantics`); propchange fires per write.
+							expect: 2,
 						},
 					],
 				},
@@ -598,6 +612,22 @@ export default {
 								[{ name: "v", old: undefined, value: 99 }],
 							],
 						},
+							{
+								name: "Round-trip back to the first-seen value fires no propschange",
+								arg: {
+									props: { v: { type: Number } },
+									actions: [
+										el => {
+											el.v = 5;
+											el.v = undefined;
+										},
+									],
+								},
+								// Net no-op: settled value === first-seen oldValue, so the
+								// propschange drain drops it. (Individual propchange events
+								// still fire — see the propchange events suite.)
+								expect: [],
+							},
 					],
 				},
 				{

--- a/test/Props.js
+++ b/test/Props.js
@@ -121,6 +121,37 @@ export default {
 							expect: 100,
 						},
 						{
+							name: "Computeds reading a pre-upgrade prop pick up the user-set value, not the default",
+							async run () {
+								let Class = FakeElement.with({
+									base: { type: Number, default: 1 },
+									derived: {
+										type: Number,
+										get () {
+											return this.base * 10;
+										},
+									},
+								});
+								let el = new Class();
+								// Pre-upgrade: write `base` as a data property, shadowing
+								// the (not-yet-installed) accessor. This is what a parser
+								// or framework would do to an element instance whose
+								// `customElements.define` hasn't run yet.
+								Object.defineProperty(el, "base", {
+									value: "5", // string — verifies parse(Number) still runs.
+									writable: true,
+									configurable: true,
+									enumerable: true,
+								});
+								el.mount();
+								return { base: el.base, derived: el.derived };
+							},
+							// derived reads via `this.base` during its first compute, which
+							// goes through the accessor → Computed_base → rawSignal (=5).
+							// No default-fallback because rawSignal is defined.
+							expect: { base: 5, derived: 50 },
+						},
+						{
 							name: "Property set before upgrade is preserved on mount",
 							// Simulates writing to a custom element instance before its
 							// `customElements.define` upgrade installs the prop accessors

--- a/test/Props.js
+++ b/test/Props.js
@@ -120,6 +120,32 @@ export default {
 							},
 							expect: 100,
 						},
+						{
+							name: "Property set before upgrade is preserved on mount",
+							// Simulates writing to a custom element instance before its
+							// `customElements.define` upgrade installs the prop accessors
+							// on the prototype: the value lands as an own data property and
+							// shadows the accessor. On mount, `Prop.initializeFor` notices
+							// `Object.hasOwn`, extracts the value, deletes the data property
+							// to expose the accessor, and re-assigns through the setter so
+							// the value passes through type parsing.
+							// See https://github.com/nudeui/element/issues/14
+							async run () {
+								let Class = FakeElement.with({
+									v: { type: Number, default: 0 },
+								});
+								let el = new Class();
+								Object.defineProperty(el, "v", {
+									value: "42", // String — verifies that parse(Number) runs.
+									writable: true,
+									configurable: true,
+									enumerable: true,
+								});
+								el.mount();
+								return el.v;
+							},
+							expect: 42,
+						},
 					],
 				},
 				{
@@ -172,6 +198,60 @@ export default {
 							// Disconnected drain bails — payload waits in queue. Reconnect
 							// dispatches the post-disconnect payload, NOT the already-fired mount.
 							expect: { mountCount: 1, afterDisconnect: 1, afterReconnect: 2 },
+						},
+						{
+							name: "Multiple writes while disconnected each fire propchange on reconnect",
+							async run () {
+								let el = new (FakeElement.with({
+									v: { type: Number, default: 0 },
+								}))();
+								el.mount();
+								let events = [];
+								el.addEventListener("propchange", e =>
+									events.push({ value: e.detail.value, oldValue: e.detail.oldValue }));
+
+								el.isConnected = false;
+								el.v = 5;
+								el.v = 10;
+								el.v = 15;
+								await flush();
+								el.isConnected = true;
+
+								return events;
+							},
+							// Three writes → three propchange events on reconnect, each carrying its
+							// own per-write `oldValue`/`value` pair. Sync-write semantics apply to
+							// the queued path too.
+							expect: [
+								{ value: 5, oldValue: 0 },
+								{ value: 10, oldValue: 5 },
+								{ value: 15, oldValue: 10 },
+							],
+						},
+						{
+							name: "Multiple writes while disconnected coalesce into one propschange on reconnect",
+							async run () {
+								let el = new (FakeElement.with({
+									v: { type: Number, default: 0 },
+								}))();
+								el.mount();
+								let calls = [];
+								el.addEventListener("propschange", e =>
+									calls.push([...e.changedProps]));
+
+								el.isConnected = false;
+								el.v = 5;
+								el.v = 10;
+								el.v = 15;
+								await flush();
+								el.isConnected = true;
+
+								return calls;
+							},
+							// Listener attached after mount, so mount's propschange is not captured.
+							// Three disconnected writes accumulate into one propschange on reconnect,
+							// with `oldValue` pinned to the first-seen value (0) and current value 15.
+							expect: [[["v", 0]]],
 						},
 					],
 				},

--- a/test/Props.js
+++ b/test/Props.js
@@ -121,7 +121,7 @@ export default {
 							expect: 100,
 						},
 						{
-							name: "Computeds reading a pre-upgrade prop pick up the user-set value, not the default",
+							name: "Pre-upgrade prop value is readable on mount, both directly and via dependent Computeds",
 							async run () {
 								let Class = FakeElement.with({
 									base: { type: Number, default: 1 },

--- a/test/Props.js
+++ b/test/Props.js
@@ -200,7 +200,7 @@ export default {
 							expect: { mountCount: 1, afterDisconnect: 1, afterReconnect: 2 },
 						},
 						{
-							name: "Multiple writes while disconnected each fire propchange on reconnect",
+							name: "Multiple writes while paused coalesce to one propchange per prop on resume",
 							async run () {
 								let el = new (FakeElement.with({
 									v: { type: Number, default: 0 },
@@ -219,14 +219,12 @@ export default {
 
 								return events;
 							},
-							// Three writes → three propchange events on reconnect, each carrying its
-							// own per-write `oldValue`/`value` pair. Sync-write semantics apply to
-							// the queued path too.
-							expect: [
-								{ value: 5, oldValue: 0 },
-								{ value: 10, oldValue: 5 },
-								{ value: 15, oldValue: 10 },
-							],
+							// Three writes while paused (disconnected) → one coalesced propchange
+							// on resume. The per-write semantics that apply to active elements
+							// (one event per write) are not useful while detached — there's no
+							// observer in real time anyway, and the consumer gets the same view
+							// either way (final value, pinned first-seen oldValue).
+							expect: [{ value: 15, oldValue: 0 }],
 						},
 						{
 							name: "Multiple writes while disconnected coalesce into one propschange on reconnect",
@@ -252,6 +250,32 @@ export default {
 							// Three disconnected writes accumulate into one propschange on reconnect,
 							// with `oldValue` pinned to the first-seen value (0) and current value 15.
 							expect: [[["v", 0]]],
+						},
+						{
+							name: "Manual pause()/resume() coalesces writes while the element stays connected",
+							async run () {
+								let Class = FakeElement.with({
+									v: { type: Number, default: 0 },
+								});
+								let el = new Class();
+								el.mount();
+								let events = [];
+								el.addEventListener("propchange", e =>
+									events.push({ value: e.detail.value, oldValue: e.detail.oldValue }));
+
+								Class.props.pause(el);
+								el.v = 5;
+								el.v = 10;
+								el.v = 15;
+								Class.props.resume(el);
+
+								return events;
+							},
+							// `pause` / `resume` is the underlying mechanism the lifecycle
+							// hooks use. Exposing it lets consumers batch a burst of writes
+							// without going through disconnect/reconnect — useful inside
+							// element methods that touch many props at once.
+							expect: [{ value: 15, oldValue: 0 }],
 						},
 					],
 				},

--- a/test/util/FakeElement.js
+++ b/test/util/FakeElement.js
@@ -42,9 +42,12 @@ export default class FakeElement extends EventTarget {
 	set isConnected (value) {
 		let was = this.#connected;
 		this.#connected = value;
-		// Stand in for the real `connectedCallback`.
+		// Stand in for the real `connectedCallback` / `disconnectedCallback`.
 		if (!was && value) {
 			this.constructor.props?.connected(this);
+		}
+		else if (was && !value) {
+			this.constructor.props?.disconnected(this);
 		}
 	}
 


### PR DESCRIPTION
## Summary

Restores the pre-#102 invariant that property writes are observable in one synchronous turn — `el.foo = 1; el.foo` returns `1`, `propchange` fires before control returns to the caller, and reads of Computed dependents inside the handler are settled. Only the per-tick `propschange` event and `updated()` callback remain batched on a microtask, which is where #51's coalescing intent properly belongs.

## How it works

- **`signals.js`** flushes dirty Computeds synchronously at the end of every `Signal.set value`. The existing topological `while (dirtyComputeds.size)` loop already prevented diamond-dep glitches; it just no longer needs to wait for a microtask. A `flushing` re-entrancy guard absorbs nested writes from subscribers, and the `MAX_FLUSH_ITERATIONS` cycle guard is unchanged.
- **`Props`** splits dispatch into two tiers:
  - `propchange` events are buffered per element only long enough for the originating write's Computed cascade to settle, then drained synchronously by `drain()` at end of the property setter (or `attributeChanged`). Re-entrant writes from handlers loop the drain until quiescent.
  - `propschange` accumulates across the tick on a microtask, with `oldValue` pinned to the first-seen value so a net round-trip is dropped from the summary.
- **`Prop.changed`** is no longer `async` (vestigial).

## Semantics

`el.x = 1; el.x = 2; el.x = 3` now fires three `propchange` events — matching native IDL setters where every assignment is observable. Per-tick coalescing lives in `propschange` / `updated()`. Handlers still see post-cascade values via `this[name]` because the topological flush completes before any dispatch.

Closes [nudeui/element#111](https://github.com/nudeui/element/issues/111).

## Test plan

- [x] All Prop / Props / Signals / Plugins tests pass (95/101; the 5 failing tests in `hooks` and the 1 skipped test in `split` are pre-existing on `main`)
- [x] Updated tests that asserted the old coalescing behavior to reflect the new sync semantics (3 propchange events for 3 writes, 2 propchange events for round-trip)
- [x] Added a `propschange` test confirming round-trips are dropped from the per-tick summary
- [x] Existing `Handler observes post-cascade values for sibling Computeds` test still passes — the synchronous topological flush settles every Computed before the first `propchange` fires
- [x] `#100` regression test (`Reconnect drains queued events without replaying mount events`) still passes — disconnected-queue-drain-on-reconnect is preserved

🤖 Generated with [Claude Code](https://claude.com/claude-code)