### PR TITLE
Fix #106 + clean attribute clear on reflected props

### DIFF
--- a/src/plugins/events/propchange.js
+++ b/src/plugins/events/propchange.js
@@ -6,6 +6,7 @@
 import { symbols } from "xtensible";
 import base, { events } from "./base.js";
 import { props } from "../props/index.js";
+import PropChangeEvent from "../props/util/PropChangeEvent.js";
 
 const { propchange } = symbols.new;
 
@@ -45,12 +46,13 @@ const hooks = {
 			let propName = this.constructor[propchange][eventName];
 			let value = this[propName];
 
-			if (value !== undefined) {
-				this.constructor[props].firePropChangeEvent(this, eventName, {
-					name: propName,
-					prop: this.constructor[props].get(propName),
-				});
+			if (value === undefined) {
+				continue;
 			}
+
+			let prop = this.constructor[props].get(propName);
+			let detail = { source: "initial", value };
+			this.dispatchEvent(new PropChangeEvent(eventName, { name: propName, prop, detail }));
 		}
 	},
 };

--- a/src/plugins/props/util/Prop.js
+++ b/src/plugins/props/util/Prop.js
@@ -254,7 +254,9 @@ let Self = class Prop {
 			if (element.setAttribute) {
 				let attributeName = change.attributeName ?? this.toAttribute;
 				let attributeValue =
-					change.attributeValue ?? change.element.getAttribute(attributeName);
+					change.attributeValue !== undefined
+						? change.attributeValue
+						: change.element.getAttribute(attributeName);
 
 				if (attributeValue === null) {
 					element.removeAttribute(attributeName);


### PR DESCRIPTION
## Summary

Two surgical bug fixes against the rolled-back `e344b1f` baseline, stacked on top of #114 so each landing has its own regression test already in place.

- **Populate detail on `first_connected` shortcut re-fires (#106)** — direct port of `1984e21` from `main`. Flips the `first_connected shortcut re-fire carries a detail` test.
- **Preserve explicit `null` in reflected attribute writes** — `??` was treating "clear this attribute" the same as "no override given," so writing `null`/`undefined` to a reflected prop didn't remove the attribute. Switch to `!== undefined`. Flips both `Clearing a reflected prop removes the attribute / undefined` and `/ null`.

## Test plan

- [x] `npx htest test/index.js` — was 88p / 10f / 4s on #114; now 91p / 7f / 4s. Remaining 7 failures are unrelated bugs the baseline tests intentionally pin.