### PR TITLE
Fix `setAttribute()` after mount not updating reflected props (closes #98)

### DIFF
--- a/src/element/members.js
+++ b/src/element/members.js
@@ -16,6 +16,14 @@ const provides = {
 
 		this.$hook("disconnected");
 	},
+
+	// Must be on the prototype before customElements.define runs — spec reads observedAttributes only if ACB is non-null.
+	attributeChangedCallback (name, oldValue, value) {
+		// super.attributeChangedCallback()
+		getSuperMethod(this, provides.attributeChangedCallback)?.call(this, name, oldValue, value);
+
+		this.$hook("attribute-changed", { name, oldValue, value });
+	},
 };
 
 export default { provides };

--- a/src/plugins/props/index.js
+++ b/src/plugins/props/index.js
@@ -1,6 +1,6 @@
 import Props from "./util/Props.js";
 import { symbols } from "xtensible";
-import { defineOwnProperty, getSuperMethod } from "xtensible/util";
+import { defineOwnProperty } from "xtensible/util";
 import { defineLazyProperty } from "../../util/lazy.js";
 
 export const { props } = symbols.known;
@@ -32,19 +32,13 @@ const hooks = {
 	disconnected () {
 		this.constructor[props].pauseEvents(this);
 	},
-};
 
-const provides = {
-	// Must be on the prototype chain by the time customElements.define runs:
-	// the spec only reads observedAttributes if attributeChangedCallback is non-null.
-	// https://html.spec.whatwg.org/multipage/custom-elements.html#element-definition
-	attributeChangedCallback (name, oldValue, value) {
-		// Same as super.attributeChangedCallback?.()
-		getSuperMethod(this, provides.attributeChangedCallback)?.call(this, name, oldValue, value);
-
+	"attribute-changed" ({ name, oldValue, value }) {
 		this.constructor[props].attributeChanged(this, name, oldValue, value);
 	},
 };
+
+const provides = {};
 
 // Internal prop values
 defineLazyProperty(provides, "props", {

--- a/src/plugins/props/index.js
+++ b/src/plugins/props/index.js
@@ -1,30 +1,16 @@
 import Props from "./util/Props.js";
 import { symbols } from "xtensible";
-import { defineOwnProperty } from "xtensible/util";
+import { defineOwnProperty, getSuperMethod } from "xtensible/util";
 import { defineLazyProperty } from "../../util/lazy.js";
 
 export const { props } = symbols.known;
-
-function first_constructor_static () {
-	// TODO how does this work if attributeChangedCallback is inherited?
-	let _attributeChangedCallback = this.prototype.attributeChangedCallback;
-	this.prototype.attributeChangedCallback = function (name, oldValue, value) {
-		this.constructor[props].attributeChanged(this, name, oldValue, value);
-		_attributeChangedCallback?.call(this, name, oldValue, value);
-	};
-
-	// FIXME how to combine with existing observedAttributes?
-	if (!Object.hasOwn(this, "observedAttributes")) {
-		Object.defineProperty(this, "observedAttributes", {
-			get: () => this[props].observedAttributes,
-			configurable: true,
-		});
-	}
-}
+const { observedAttributes } = symbols.known;
 
 const hooks = {
 	setup () {
-		if (Object.hasOwn(this, "props")) {
+		// Skip if the static observedAttributes getter already ran the install —
+		// it's the registration-time path that fires before any instance exists.
+		if (Object.hasOwn(this, "props") && !Object.hasOwn(this, observedAttributes)) {
 			this.defineProps();
 		}
 	},
@@ -34,8 +20,6 @@ const hooks = {
 			this.addEventListener("propchange", this.propChangedCallback);
 		}
 	},
-
-	first_constructor_static,
 
 	constructed () {
 		this.constructor[props].initializeFor(this);
@@ -51,11 +35,15 @@ const hooks = {
 };
 
 const provides = {
-	// ...composed({
-	// 	attributeChangedCallback (name, oldValue, value) {
-	// 		this.constructor[props].attributeChanged(this, name, oldValue, value);
-	// 	},
-	// }),
+	// Must be on the prototype chain by the time customElements.define runs:
+	// the spec only reads observedAttributes if attributeChangedCallback is non-null.
+	// https://html.spec.whatwg.org/multipage/custom-elements.html#element-definition
+	attributeChangedCallback (name, oldValue, value) {
+		// Same as super.attributeChangedCallback?.()
+		getSuperMethod(this, provides.attributeChangedCallback)?.call(this, name, oldValue, value);
+
+		this.constructor[props].attributeChanged(this, name, oldValue, value);
+	},
 };
 
 // Internal prop values
@@ -96,6 +84,21 @@ const providesStatic = {
 	// 		return [...superProps, ...thisProps];
 	// 	},
 	// }),
+
+	get observedAttributes () {
+		if (Object.hasOwn(this, observedAttributes)) {
+			return this[observedAttributes];
+		}
+
+		// Reserve the cache before defineProps so any consumer that reads
+		// Class.observedAttributes during the install (e.g., a define-props
+		// hook listener) gets the in-flight list instead of recursing.
+		this[observedAttributes] = [];
+		this.defineProps();
+
+		// FIXME how to combine with existing observedAttributes?
+		return (this[observedAttributes] = this[props].observedAttributes);
+	},
 };
 
 defineOwnProperty(providesStatic, props, function () {


### PR DESCRIPTION
Closes #98 — `setAttribute()` after mount didn't update reflected props because `attributeChangedCallback` wasn't on the prototype at `customElements.define` time, so the spec never read `observedAttributes`.

Per [Lea's review](https://github.com/nudeui/element/pull/117#issuecomment-4467916069): `NudeElement` now owns `attributeChangedCallback` (in `src/element/members.js`, alongside `connectedCallback` / `disconnectedCallback`) and fires an `attribute-changed` hook with `{ name, oldValue, value }`. The props plugin listens to that hook instead of overriding ACB — same shape it already uses for `connected` / `disconnected`.

**Bonus**: also flips "removeAttribute collapses a reflected prop to its default" green — same root cause.

## Test plan

- [x] `npm run test` — both regression tests pass: "Post-mount setAttribute updates the property (issue #98)" and "removeAttribute collapses a reflected prop to its default"
- [x] No regressions in unrelated tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)