### PR TITLE
Fire source's propchange before cascading to dependents

### DIFF
--- a/src/plugins/props/util/Props.js
+++ b/src/plugins/props/util/Props.js
@@ -144,16 +144,7 @@ export default class Props extends Map {
 	eventDispatchQueue = new WeakMap();
 
 	propChanged (element, prop, change) {
-		// Update all props that have this prop as a dependency
-		let dependents = this.dependents[prop.name] ?? new Set();
-
-		for (let dependent of dependents) {
-			if (dependent.dependsOn(prop, element)) {
-				dependent.update(element, prop);
-			}
-		}
-
-		// Fire propchange event
+		// Source-first: fire before cascading so listeners hear the written prop first.
 		let eventNames = ["propchange", ...(prop.eventNames ?? [])];
 		for (let eventName of eventNames) {
 			this.firePropChangeEvent(element, eventName, {
@@ -161,6 +152,15 @@ export default class Props extends Map {
 				prop,
 				detail: change,
 			});
+		}
+
+		// Update all props that have this prop as a dependency
+		let dependents = this.dependents[prop.name] ?? new Set();
+
+		for (let dependent of dependents) {
+			if (dependent.dependsOn(prop, element)) {
+				dependent.update(element, prop);
+			}
 		}
 	}
 


### PR DESCRIPTION
## Summary

`Props.propChanged` previously cascaded to dependents first and fired the source's `propchange` event last. This meant `el.plain = 5` produced events for `computed` and `fnDefault` before the event for `plain` — surprising for listeners who expect to hear about the prop they just wrote to first.

Swap the order: fire the source's event, then cascade. The cascade still runs synchronously and dependent events follow in declaration order.

## Test impact

- ✅ `defaultProp re-fires when its source prop changes` — was red on cascade-first order, now passes.
- ✅ `default() with reactive deps: synthetic prop event fires before declared` and `Events fan out across plain, get, and default() props` — both #113 baseline tests had their expectations corrected upstream on the `props-behavioral-tests` branch (per [#113 design clarification](https://github.com/nudeui/element/issues/113#issuecomment-4460448969): synthetic default props are consumer-visible, analogous to `.value`/`.defaultValue` on native form controls). They were red until source-first ordering landed; this PR makes them pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)