### PR TITLE
Drain queued propchange events on reconnect

### DIFF
--- a/src/plugins/props/index.js
+++ b/src/plugins/props/index.js
@@ -42,7 +42,11 @@ const hooks = {
 	},
 
 	connected () {
-		this.constructor[props].dispatchQueuedEvents(this);
+		this.constructor[props].resumeEvents(this);
+	},
+
+	disconnected () {
+		this.constructor[props].pauseEvents(this);
 	},
 };
 

--- a/src/plugins/props/index.js
+++ b/src/plugins/props/index.js
@@ -42,7 +42,7 @@ const hooks = {
 	},
 
 	connected () {
-		this.constructor[props].drainFor(this);
+		this.constructor[props].dispatchQueuedEvents(this);
 	},
 };
 

--- a/src/plugins/props/index.js
+++ b/src/plugins/props/index.js
@@ -40,6 +40,10 @@ const hooks = {
 	constructed () {
 		this.constructor[props].initializeFor(this);
 	},
+
+	connected () {
+		this.constructor[props].drainFor(this);
+	},
 };
 
 const provides = {

--- a/src/plugins/props/util/Props.js
+++ b/src/plugins/props/util/Props.js
@@ -193,15 +193,19 @@ export default class Props extends Map {
 			prop.initializeFor(element);
 		}
 
-		// Dispatch any events that were queued
+		this.drainFor(element);
+	}
+
+	drainFor (element) {
 		let queue = this.eventDispatchQueue.get(element);
-
-		if (queue) {
-			for (let event of queue) {
-				element.dispatchEvent?.(event);
-			}
-
-			this.eventDispatchQueue.delete(element);
+		if (!queue) {
+			return;
 		}
+
+		for (let event of queue) {
+			element.dispatchEvent?.(event);
+		}
+
+		this.eventDispatchQueue.delete(element);
 	}
 }

--- a/src/plugins/props/util/Props.js
+++ b/src/plugins/props/util/Props.js
@@ -193,10 +193,10 @@ export default class Props extends Map {
 			prop.initializeFor(element);
 		}
 
-		this.drainFor(element);
+		this.dispatchQueuedEvents(element);
 	}
 
-	drainFor (element) {
+	dispatchQueuedEvents (element) {
 		let queue = this.eventDispatchQueue.get(element);
 		if (!queue) {
 			return;

--- a/src/plugins/props/util/Props.js
+++ b/src/plugins/props/util/Props.js
@@ -141,6 +141,12 @@ export default class Props extends Map {
 		}
 	}
 
+	/**
+	 * Elements currently holding propchange event dispatch.
+	 * @type {WeakSet<HTMLElement>}
+	 */
+	#paused = new WeakSet();
+
 	eventDispatchQueue = new WeakMap();
 
 	propChanged (element, prop, change) {
@@ -167,7 +173,7 @@ export default class Props extends Map {
 	firePropChangeEvent (element, eventName, eventProps) {
 		let event = new PropChangeEvent(eventName, eventProps);
 
-		if (element.isConnected && eventProps.prop.initialized) {
+		if (!this.#paused.has(element) && eventProps.prop.initialized) {
 			element.dispatchEvent?.(event);
 		}
 		else {
@@ -193,10 +199,16 @@ export default class Props extends Map {
 			prop.initializeFor(element);
 		}
 
-		this.dispatchQueuedEvents(element);
+		this.resumeEvents(element);
 	}
 
-	dispatchQueuedEvents (element) {
+	pauseEvents (element) {
+		this.#paused.add(element);
+	}
+
+	resumeEvents (element) {
+		this.#paused.delete(element);
+
 		let queue = this.eventDispatchQueue.get(element);
 		if (!queue) {
 			return;

--- a/test/plugins/props/lifecycle.js
+++ b/test/plugins/props/lifecycle.js
@@ -1,3 +1,5 @@
+import { props as propsSymbol } from "../../../src/plugins/props/index.js";
+
 export default {
 	name: "Disconnect / reconnect lifecycle",
 
@@ -23,6 +25,37 @@ export default {
 				after: [
 					["v", 1],
 					["v", 2],
+				],
+			},
+		},
+		{
+			name: "pauseEvents holds dispatch until resumeEvents drains in order",
+			run () {
+				let { element } = this.data;
+				let log = [];
+				element.addEventListener("propchange", e => log.push([e.name, e.detail.value]));
+
+				element.a = 1; // fires immediately
+				let beforePause = log.length;
+
+				let props = element.constructor[propsSymbol];
+				props.pauseEvents(element);
+
+				element.b = "x";
+				element.a = 2;
+
+				let duringPause = log.length - beforePause;
+				props.resumeEvents(element);
+
+				return { duringPause, afterResume: log };
+			},
+			arg: { props: { a: { type: Number, default: 42 }, b: {} } },
+			expect: {
+				duringPause: 0,
+				afterResume: [
+					["a", 1],
+					["b", "x"],
+					["a", 2],
 				],
 			},
 		},


### PR DESCRIPTION
## Summary

Replaces the implicit `isConnected` queue check with an explicit `pauseEvents` / `resumeEvents` primitive on `Props`, gated by a `#paused` WeakSet. Lifecycle hooks wire `disconnected → pauseEvents` and `connected → resumeEvents` — same fix, first-class primitive for #51 batching to build on.

Addresses [Lea's review](https://github.com/nudeui/element/pull/120#pullrequestreview-4301101960).

## Tests

96/102 PASS locally (4 pre-existing skipped). The original reconnect regression test is unchanged. One new test covers the primitive directly: pause → writes → resume, asserting no dispatch during pause and ordered drain on resume.

The 2 reds (`Post-mount setAttribute…`, `removeAttribute collapses…`) are owned by #117 and will go green once it merges — this PR deliberately doesn't carry that commit.