### PR TITLE
Fix early-return conflation in Prop.set (oldValue + propchange skip)

### DIFF
--- a/src/plugins/props/util/Prop.js
+++ b/src/plugins/props/util/Prop.js
@@ -215,11 +215,15 @@ let Self = class Prop {
 			parsedValue = this.spec.convert.call(element, parsedValue);
 		}
 
-		if (this.equals(parsedValue, oldValue)) {
-			return;
+		// Resolve the default lazily so equality and propchange.oldValue match the getter.
+		if (
+			oldValue === undefined &&
+			!this.spec.get &&
+			this.default !== undefined &&
+			typeof this.default !== "function"
+		) {
+			oldValue = this.get(element);
 		}
-
-		element.props[this.name] = parsedValue;
 
 		let change = {
 			element,
@@ -228,6 +232,7 @@ let Self = class Prop {
 			oldValue,
 		};
 
+		// Reflect before the equality check: an explicit equal-value write still updates the attribute.
 		if (source === "property") {
 			// Reflect to attribute?
 			if (this.toAttribute) {
@@ -253,6 +258,12 @@ let Self = class Prop {
 				oldAttributeValue,
 			});
 		}
+
+		if (this.equals(parsedValue, oldValue)) {
+			return;
+		}
+
+		element.props[this.name] = parsedValue;
 
 		this.changed(element, change);
 	}

--- a/test/plugins/props/propchange.js
+++ b/test/plugins/props/propchange.js
@@ -132,11 +132,25 @@ export default {
 		{
 			name: "Assigning current default-resolved value is a no-op",
 			run () {
-				this.data.element.v = 42;
-				return this.data.events;
+				let { element, events } = this.data;
+				let before = events.length;
+				element.v = 42;
+				return events.length - before;
 			},
 			arg: { props: { v: { type: Number, default: 42 } } },
-			expect: [["v", 42]],
+			expect: 0,
+		},
+		{
+			name: "First write reports the resolved default as oldValue",
+			run () {
+				let { element } = this.data;
+				let oldValue;
+				element.addEventListener("propchange", e => (oldValue = e.detail.oldValue));
+				element.prop = "new";
+				return oldValue;
+			},
+			arg: { props: { prop: { default: "initial" } } },
+			expect: "initial",
 		},
 		{
 			name: "Three writes fire three propchange events in order, synchronously",


### PR DESCRIPTION
## Summary

`set()` in `Prop.js` had a single `if (equals(parsedValue, oldValue)) return;` that skipped three concerns at once — attribute reflection, propchange dispatch, and the storage write. Because `element.props[name]` was never populated with a literal default, `oldValue` was `undefined` on the first write, masking the bug behind a false equality.

This PR splits those concerns:

- **`set()`** resolves the default lazily when `element.props[name]` is `undefined` and the prop has a literal default. That gives the equality check and `propchange.detail.oldValue` the same value the getter would return — *without* writing into `element.props[name]`, which stays as the "explicit value" indicator. Function defaults stay lazy (their original call-site timing); `defaultProp` resolves through the dependency cascade.
- **`set()`** runs the reflection branch *before* the equality check, preserving the "explicit equal write reflects" contract (#113). The inner attribute-mismatch gate still skips redundant DOM writes.

New regression test pins `propchange.detail.oldValue` to the resolved default on first write — the only test in the suite asserting on `detail.oldValue`. The pre-existing `Assigning current default-resolved value is a no-op` baseline was also tightened to use a strict count delta (`events.length - before === 0`) rather than relying on hTest's prefix-based array equality, which silently allowed the bug.

Uncovered while implementing propchange coalescing — the latent bug surfaced once consumers started reading `detail.oldValue` on coalesced events.

### Evolution

The first version of this PR cached resolved literal defaults *into* `element.props[name]` during `initializeFor`. [@LeaVerou flagged](https://github.com/nudeui/element/pull/122#issuecomment-) that this collapses two distinct states ("explicit equal write" vs "at default") into one. The current version resolves lazily in `set()` instead, preserving the distinction.

## Test plan

- [x] `npm test` — both new and pre-existing target tests pass with the fix
- [x] Both target tests fail correctly when `Prop.js` is reverted (RED state verified)
- [x] `Explicit write equal to the default still reflects to the attribute` (the #113 contract) still passes
- [x] `element.props[name]` remains `undefined` for "at default" state — Lea's invariant preserved

🤖 Generated with [Claude Code](https://claude.com/claude-code)