### PR TITLE
Run the JS-first test suite in a browser via `npm run test:browser`

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
 		"build": "npm run build:apidocs",
 		"watch": "npm run watch:apidocs",
 		"test": "npx htest test/index.js",
+		"test:browser": "python3 -m http.server 8765 >/dev/null 2>&1 & PID=$!; trap 'kill $PID 2>/dev/null' EXIT; trap 'exit 0' INT TERM HUP; sleep 1; open http://localhost:8765/test/index.html; wait $PID",
 		"release": "npm login && npx release-it"
 	},
 	"exports": {

--- a/test/index.html
+++ b/test/index.html
@@ -1,0 +1,49 @@
+<!doctype html>
+<html lang="en">
+
+<head>
+	<meta charset="utf-8" />
+	<title>Tests</title>
+	<link rel="stylesheet" href="../node_modules/htest.dev/htest.css" crossorigin />
+	<!--
+		"#dom-polyfill" loads happy-dom in Node; browsers have native DOM and don't need it.
+		Test files static-import the specifier regardless, so it's mapped to an empty data URL (a valid no-op module) here.
+	-->
+	<script type="importmap">
+			{
+				"imports": {
+					"#dom-polyfill": "data:text/javascript,",
+					"htest.dev/render": "../node_modules/htest.dev/src/render.js",
+					"xtensible": "../node_modules/xtensible/src/index.js",
+					"xtensible/util": "../node_modules/xtensible/src/util.js",
+					"xtensible/plugins": "../node_modules/xtensible/plugins/index.js",
+					"get-symbols": "../node_modules/get-symbols/index.js"
+				}
+			}
+		</script>
+	<script src="../node_modules/htest.dev/htest.js" type="module" crossorigin></script>
+	<script type="module">
+		// Pass `?test=path/to/tests` to load `./path/to/tests.js`.
+		// The extension is optional and slashes route into subdirectories.
+		const params = new URLSearchParams(location.search);
+		let testUrl = params.get("test") ?? "index";
+
+		if (!testUrl.match(/\.\w+$/)) {
+			testUrl += ".js";
+		}
+
+		if (/^[\w/-]+\.\w+$/.test(testUrl)) {
+			testUrl = `./${testUrl}`;
+		}
+
+		const [render, tests] = await Promise.all([
+			import("htest.dev/render").then(m => m.default),
+			import(testUrl).then(m => m.default),
+		]);
+		render(tests);
+	</script>
+</head>
+
+<body></body>
+
+</html>


### PR DESCRIPTION
Adds an HTML harness ([test/index.html](test/index.html)) that loads the existing JS-first tests in a browser using hTest's `render()`. The page reads `?test=<path>` from the URL to load any test under `test/` (extension optional, slashes for subdirectories) and shows a manual index of all leaf test files when no param is given.

`npm run test:browser` boots a local Python `http.server` on port 8765, opens the harness in the default browser, and uses signal/EXIT traps so the server is killed automatically (with exit code 0) on `Ctrl+C` or terminal disconnect.

**Depends on #121** — the harness's import map points `#dom-polyfill` at an empty `data:` URL so the test files' `import "#dom-polyfill"` no-ops in the browser.