### PR TITLE
Split per-element prop state into ElementProp / ElementProps

### DIFF
--- a/src/element/members.js
+++ b/src/element/members.js
@@ -16,14 +16,6 @@ const provides = {
 
 		this.$hook("disconnected");
 	},
-
-	// Must be on the prototype before customElements.define runs — spec reads observedAttributes only if ACB is non-null.
-	attributeChangedCallback (name, oldValue, value) {
-		// super.attributeChangedCallback()
-		getSuperMethod(this, provides.attributeChangedCallback)?.call(this, name, oldValue, value);
-
-		this.$hook("attribute-changed", { name, oldValue, value });
-	},
 };
 
 export default { provides };

--- a/src/plugins/events/propchange.js
+++ b/src/plugins/events/propchange.js
@@ -50,7 +50,7 @@ const hooks = {
 				continue;
 			}
 
-			let prop = this.constructor[props].get(propName);
+			let prop = this.props.get(propName);
 			let detail = { source: "initial", value };
 			this.dispatchEvent(new PropChangeEvent(eventName, { name: propName, prop, detail }));
 		}

--- a/src/plugins/props/index.js
+++ b/src/plugins/props/index.js
@@ -2,6 +2,7 @@ import Props from "./util/Props.js";
 import ElementProps from "./util/ElementProps.js";
 import { symbols } from "xtensible";
 import { defineOwnProperty } from "xtensible/util";
+import { defineLazyProperty } from "../../util/lazy.js";
 
 export const { props } = symbols.known;
 const { observedAttributes } = symbols.known;
@@ -21,32 +22,21 @@ const hooks = {
 		}
 	},
 
-	constructed () {
-		// Create the per-element ElementProps now, after the element constructor
-		// and all sync pre-mount setup has completed. The ElementProps
-		// constructor self-installs as `this.props` and runs the full mount
-		// pass (shadow recovery + attr-read + default-fire), then resumes
-		// event dispatch.
-		new ElementProps(this);
-	},
-
 	connected () {
-		this.props?.resumeEvents();
+		this.props.resumeEvents();
 	},
 
 	disconnected () {
-		this.props?.pauseEvents();
+		this.props.pauseEvents();
 	},
 
 	"attribute-changed" ({ name, oldValue }) {
-		// Pre-mount attribute writes (before `constructed` fires) leave the
-		// attribute on the element; ElementProps' constructor reads it during
-		// init. No need to handle them here.
-		this.props?.attributeChanged(name, oldValue);
+		this.props.attributeChanged(name, oldValue);
 	},
 };
 
 const provides = {
+	props: undefined, // see below
 
 	constructor: {
 		defineProps (def = this.props) {
@@ -77,6 +67,21 @@ const provides = {
 		},
 	},
 };
+
+/**
+ * Per-element collection of {@link ElementProp} wrappers, materialized on
+ * first access. The {@link ElementProps} constructor self-installs as the
+ * element's own `props` data property, shadowing this accessor from then on.
+ */
+defineLazyProperty(provides, "props", {
+	get () {
+		if (this.constructor.props) {
+			return new ElementProps(this);
+		}
+	},
+	configurable: true,
+	writable: true,
+});
 
 defineOwnProperty(provides.constructor, props, function () {
 	return new Props(this);

--- a/src/plugins/props/index.js
+++ b/src/plugins/props/index.js
@@ -5,7 +5,6 @@ import { defineOwnProperty } from "xtensible/util";
 import { defineLazyProperty } from "../../util/lazy.js";
 
 export const { props } = symbols.known;
-const { observedAttributes } = symbols.known;
 
 const hooks = {
 	setup () {

--- a/src/plugins/props/index.js
+++ b/src/plugins/props/index.js
@@ -1,7 +1,7 @@
 import Props from "./util/Props.js";
+import ElementProps from "./util/ElementProps.js";
 import { symbols } from "xtensible";
 import { defineOwnProperty } from "xtensible/util";
-import { defineLazyProperty } from "../../util/lazy.js";
 
 export const { props } = symbols.known;
 const { observedAttributes } = symbols.known;
@@ -22,41 +22,29 @@ const hooks = {
 	},
 
 	constructed () {
-		this.constructor[props].initializeFor(this);
+		// Create the per-element ElementProps now, after the element constructor
+		// and all sync pre-mount setup has completed. The ElementProps
+		// constructor self-installs as `this.props` and runs the full mount
+		// pass (shadow recovery + attr-read + default-fire), then resumes
+		// event dispatch.
+		new ElementProps(this);
 	},
 
 	connected () {
-		this.constructor[props].resumeEvents(this);
+		this.props?.resumeEvents();
 	},
 
 	disconnected () {
-		this.constructor[props].pauseEvents(this);
+		this.props?.pauseEvents();
 	},
 
-	"attribute-changed" ({ name, oldValue, value }) {
-		this.constructor[props].attributeChanged(this, name, oldValue, value);
+	"attribute-changed" ({ name, oldValue }) {
+		// Pre-mount attribute writes (before `constructed` fires) leave the
+		// attribute on the element; ElementProps' constructor reads it during
+		// init. No need to handle them here.
+		this.props?.attributeChanged(name, oldValue);
 	},
 };
-
-const provides = {};
-
-// Internal prop values
-defineLazyProperty(provides, "props", {
-	get () {
-		return {};
-	},
-	configurable: true,
-	writable: true,
-});
-
-// Ignore mutations on these attributes
-defineLazyProperty(provides, "ignoredAttributes", {
-	get () {
-		return new Set();
-	},
-	configurable: true,
-	writable: true,
-});
 
 const providesStatic = {
 	defineProps (def = this.props) {
@@ -70,14 +58,6 @@ const providesStatic = {
 
 		this[props].add(env.props);
 	},
-
-	// ...composed({
-	// 	get observedAttributes () {
-	// 		let thisProps = this[props].observedAttributes ?? [];
-	// 		let superProps = this.super?.observedAttributes ?? [];
-	// 		return [...superProps, ...thisProps];
-	// 	},
-	// }),
 
 	get observedAttributes () {
 		if (Object.hasOwn(this, observedAttributes)) {
@@ -99,4 +79,4 @@ defineOwnProperty(providesStatic, props, function () {
 	return new Props(this);
 });
 
-export default { hooks, provides, providesStatic };
+export default { hooks, providesStatic };

--- a/src/plugins/props/index.js
+++ b/src/plugins/props/index.js
@@ -1,7 +1,7 @@
 import Props from "./util/Props.js";
 import ElementProps from "./util/ElementProps.js";
 import { symbols } from "xtensible";
-import { defineOwnProperty } from "xtensible/util";
+import { defineOwnProperty, getSuperMethod } from "xtensible/util";
 import { defineLazyProperty } from "../../util/lazy.js";
 
 export const { props } = symbols.known;
@@ -34,6 +34,14 @@ const hooks = {
 
 const provides = {
 	props: undefined, // see below
+
+	// Must be on the prototype before customElements.define runs — spec reads observedAttributes only if ACB is non-null.
+	attributeChangedCallback (name, oldValue, value) {
+		// super.attributeChangedCallback()
+		getSuperMethod(this, provides.attributeChangedCallback)?.call(this, name, oldValue, value);
+
+		this.$hook("attribute-changed", { name, oldValue, value });
+	},
 
 	constructor: {
 		defineProps (def = this.props) {

--- a/src/plugins/props/index.js
+++ b/src/plugins/props/index.js
@@ -46,37 +46,40 @@ const hooks = {
 	},
 };
 
-const providesStatic = {
-	defineProps (def = this.props) {
-		if (def instanceof Props && def.Class === this) {
-			// Already defined
-			return null;
-		}
+const provides = {
 
-		let env = { props: def };
-		this.$hook("define-props", env);
+	constructor: {
+		defineProps (def = this.props) {
+			if (def instanceof Props && def.Class === this) {
+				// Already defined
+				return null;
+			}
 
-		this[props].add(env.props);
-	},
+			let env = { props: def };
+			this.$hook("define-props", env);
 
-	get observedAttributes () {
-		if (Object.hasOwn(this, observedAttributes)) {
-			return this[observedAttributes];
-		}
+			this[props].add(env.props);
+		},
 
-		// Reserve the cache before defineProps so any consumer that reads
-		// Class.observedAttributes during the install (e.g., a define-props
-		// hook listener) gets the in-flight list instead of recursing.
-		this[observedAttributes] = [];
-		this.defineProps();
+		get observedAttributes () {
+			if (Object.hasOwn(this, observedAttributes)) {
+				return this[observedAttributes];
+			}
 
-		// FIXME how to combine with existing observedAttributes?
-		return (this[observedAttributes] = this[props].observedAttributes);
+			// Reserve the cache before defineProps so any consumer that reads
+			// Class.observedAttributes during the install (e.g., a define-props
+			// hook listener) gets the in-flight list instead of recursing.
+			this[observedAttributes] = [];
+			this.defineProps();
+
+			// FIXME how to combine with existing observedAttributes?
+			return (this[observedAttributes] = this[props].observedAttributes);
+		},
 	},
 };
 
-defineOwnProperty(providesStatic, props, function () {
+defineOwnProperty(provides.constructor, props, function () {
 	return new Props(this);
 });
 
-export default { hooks, providesStatic };
+export default { hooks, provides };

--- a/src/plugins/props/index.js
+++ b/src/plugins/props/index.js
@@ -9,9 +9,7 @@ const { observedAttributes } = symbols.known;
 
 const hooks = {
 	setup () {
-		// Skip if the static observedAttributes getter already ran the install —
-		// it's the registration-time path that fires before any instance exists.
-		if (Object.hasOwn(this, "props") && !Object.hasOwn(this, observedAttributes)) {
+		if (Object.hasOwn(this, "props")) {
 			this.defineProps();
 		}
 	},
@@ -52,18 +50,11 @@ const provides = {
 		},
 
 		get observedAttributes () {
-			if (Object.hasOwn(this, observedAttributes)) {
-				return this[observedAttributes];
-			}
-
-			// Reserve the cache before defineProps so any consumer that reads
-			// Class.observedAttributes during the install (e.g., a define-props
-			// hook listener) gets the in-flight list instead of recursing.
-			this[observedAttributes] = [];
-			this.defineProps();
-
 			// FIXME how to combine with existing observedAttributes?
-			return (this[observedAttributes] = this[props].observedAttributes);
+			let attributes = [...this[props].allValues()]
+				.map(prop => prop.reflect.from)
+				.filter(Boolean);
+			return [...new Set(attributes)];
 		},
 	},
 };
@@ -84,7 +75,7 @@ defineLazyProperty(provides, "props", {
 });
 
 defineOwnProperty(provides.constructor, props, function () {
-	return new Props(this);
+	return new Props(this, this.props);
 });
 
 export default { hooks, provides };

--- a/src/plugins/props/util.js
+++ b/src/plugins/props/util.js
@@ -32,3 +32,16 @@ export function sortObject (obj, fn) {
 export function capitalize (str) {
 	return str[0].toUpperCase() + str.slice(1);
 }
+
+export function isArrowFunction (fn) {
+	return typeof fn === "function" && !fn.prototype;
+}
+
+/**
+ * Is a function that is not an arrow function
+ * @param {*} fn
+ * @returns {boolean}
+ */
+export function isRegularFunction (fn) {
+	return typeof fn === "function" && fn.prototype;
+}

--- a/src/plugins/props/util.js
+++ b/src/plugins/props/util.js
@@ -32,16 +32,3 @@ export function sortObject (obj, fn) {
 export function capitalize (str) {
 	return str[0].toUpperCase() + str.slice(1);
 }
-
-export function isArrowFunction (fn) {
-	return typeof fn === "function" && !fn.prototype;
-}
-
-/**
- * Is a function that is not an arrow function
- * @param {*} fn
- * @returns {boolean}
- */
-export function isRegularFunction (fn) {
-	return typeof fn === "function" && fn.prototype;
-}

--- a/src/plugins/props/util/ElementProp.js
+++ b/src/plugins/props/util/ElementProp.js
@@ -1,98 +1,122 @@
 import { resolveValue } from "../util.js";
 
+/**
+ * Per-element wrapper around a {@link Prop} spec.
+ * Holds the current and previous value for one prop on one element, and the
+ * per-element behavior (get, set, update, cascade) for that prop.
+ */
 export default class ElementProp {
 	/**
-	 * Internal value
+	 * Current stored value. `undefined` means no explicit value has been set,
+	 * which triggers default resolution on read.
 	 */
 	value;
 
 	/**
-	 *
-	 * @param {HTMLElement} element
-	 * @param {Prop} spec
+	 * Last value that was different from the current one (i.e. the value
+	 * before the most recent change that passed the equality check).
 	 */
-	constructor (element, spec) {
-		this.element = element;
+	oldValue;
+
+	/**
+	 * @param {ElementProps} props The owning per-element collection.
+	 * @param {Prop} spec The class-level prop spec.
+	 */
+	constructor (props, spec) {
+		this.props = props;
 		this.spec = spec;
 
-		let name = this.spec.name;
+		// Register before any side effects, so re-entrant lookups during the
+		// init below (e.g. a dependent's getter reading `this.someOtherProp`)
+		// find this wrapper in the Map.
+		props.set(spec.name, this);
+
+		let { name, reflect, defaultProp, get: computed } = spec;
+		let { element } = props;
+
 		if (Object.hasOwn(element, name)) {
-			// A local data property will shadow the accessor that is defined on the prototype
+			// A local data property (e.g. a class field, or a pre-mount write
+			// that was shadowed onto the element) covers the prototype accessor.
 			// See https://github.com/nudeui/element/issues/14
 			let value = element[name];
-			delete element[name]; // Deleting the data property will uncover the accessor
-			element[name] = value; // Invoking the accessor means the value doesn't skip parsing
+			delete element[name];
+			this.set(value, { source: "property" });
 		}
-		// TODO this needs editing
-		else if (element.props[name] === undefined && !this.spec.defaultProp) {
-			// Is not set and its default is not another prop
-			this.changed(element, { source: "default", element });
+		else if (reflect.from && element.hasAttribute(reflect.from)) {
+			this.set(element.getAttribute(reflect.from), {
+				source: "attribute",
+				name: reflect.from,
+			});
 		}
+		else if (!defaultProp && !computed) {
+			// Plain prop (value-or-function default, no `get`, no `defaultProp`).
+			// Computed / defaultProp'd props don't need this — they receive their
+			// initial value via the cascade from their dependencies.
+			this.changed({ source: "default" });
+		}
+	}
+
+	get element () {
+		return this.props.element;
 	}
 
 	get name () {
 		return this.spec.name;
 	}
 
-	get type () {
-		return this.spec.type;
-	}
-
 	/**
-	 * Read this prop's current value for an element, falling back to its default.
-	 * @param {HTMLElement} element
+	 * Read this prop's current value, falling back to its default if unset.
 	 */
 	get () {
-		let element = this.element;
-		let value = this.value;
-
-		if (value === undefined) {
-			this.update(element);
-			value = this.value;
+		if (this.value === undefined) {
+			this.update();
 		}
 
-		if (value === undefined) {
-			if (this.defaultProp) {
-				value = this.defaultProp.get(element);
-			}
-			else if (this.default !== undefined) {
-				value = resolveValue(this.default, [element, element]);
-
-				try {
-					value = this.parse(value);
-				}
-				catch (e) {
-					console.warn(
-						"Failed to parse default value",
-						value,
-						`for prop ${this.name}. Original error was: `,
-						e,
-					);
-					return null;
-				}
-
-				if (this.spec.convert) {
-					value = this.spec.convert.call(element, value);
-				}
-			}
+		if (this.value !== undefined) {
+			return this.value;
 		}
 
-		return value;
+		let { spec, element } = this;
+		let raw;
+
+		if (spec.defaultProp) {
+			raw = this.props.forSpec(spec.defaultProp).get();
+		}
+		else if (spec.default !== undefined) {
+			raw = resolveValue(spec.default, [element, element]);
+		}
+		else {
+			return undefined;
+		}
+
+		let value;
+		try {
+			value = spec.parse(raw);
+		}
+		catch (e) {
+			console.warn(
+				"Failed to parse default value",
+				raw,
+				`for prop ${this.name}. Original error was: `,
+				e,
+			);
+			return null;
+		}
+
+		return this.convert(value);
 	}
 
 	/**
-	 * Write a value to an element: parse, convert, store, and reflect to attribute when applicable.
-	 * @param {HTMLElement} element
-	 * @param {*} value Raw value (string from an attribute, or any from a property write).
+	 * Write a value: parse, convert, store, and reflect to attribute when applicable.
+	 * @param {*} value Raw value (string from an attribute, any from a property write).
 	 * @param {{source?: string, name?: string, oldAttributeValue?: string | null}} [options]
 	 */
-	set (element, value, { source, name, oldAttributeValue } = {}) {
-		let oldValue = element.props[this.name];
-
-		let parsedValue;
+	set (value, { source, name, oldAttributeValue } = {}) {
+		let { spec, element } = this;
+		let parsed;
 
 		try {
-			parsedValue = this.parse(value);
+			parsed = spec.parse(value);
 		}
 		catch (e) {
 			// Abort mission
@@ -106,43 +130,43 @@ export default class ElementProp {
 		// removeAttribute() arrives as null; collapse to undefined so the prop
 		// reverts to its natural empty state. Property writes of null remain a
 		// legitimate user value.
-		if (source === "attribute" && parsedValue === null) {
-			parsedValue = undefined;
+		if (source === "attribute" && parsed === null) {
+			parsed = undefined;
 		}
 
-		if (this.spec.convert) {
-			parsedValue = this.spec.convert.call(element, parsedValue);
-		}
+		parsed = this.convert(parsed);
 
-		if (this.equals(parsedValue, oldValue)) {
+		if (spec.equals(parsed, this.value)) {
 			return;
 		}
 
-		element.props[this.name] = parsedValue;
+		this.oldValue = this.value;
+		this.value = parsed;
 
 		let change = {
-			element,
 			source,
-			value: parsedValue,
-			oldValue,
+			value: parsed,
+			oldValue: this.oldValue,
 		};
 
-		if (source === "property") {
-			// Reflect to attribute?
-			if (this.spec.reflect.to) {
-				let attributeName = this.spec.reflect.to;
-				let attributeValue = this.stringify(parsedValue);
-				let oldAttributeValue = element.getAttribute(attributeName);
+		if (source === "property" && spec.reflect.to) {
+			let attributeName = spec.reflect.to;
+			let attributeValue = spec.stringify(parsed);
+			let oldAttributeValue = element.getAttribute(attributeName);
 
-				if (oldAttributeValue !== attributeValue) {
-					// TODO what if another prop is reflected *from* this attribute?
-					element.ignoredAttributes.add(attributeName);
+			if (oldAttributeValue !== attributeValue) {
+				// TODO what if another prop is reflected *from* this attribute?
+				Object.assign(change, { attributeName, attributeValue, oldAttributeValue });
 
-					Object.assign(change, { attributeName, attributeValue, oldAttributeValue });
-					this.applyChange(element, { ...change, source: "attribute" });
-
-					element.ignoredAttributes.delete(attributeName);
+				let ignored = this.props.ignoredAttributes;
+				ignored.add(attributeName);
+				if (attributeValue === null) {
+					element.removeAttribute(attributeName);
 				}
+				else {
+					element.setAttribute(attributeName, attributeValue);
+				}
+				ignored.delete(attributeName);
 			}
 		}
 		else if (source === "attribute") {
@@ -153,81 +177,102 @@ export default class ElementProp {
 			});
 		}
 
-		this.changed(element, change);
+		this.changed(change);
 	}
 
 	/**
-	 * Apply a change descriptor to an element by writing through the matching attribute or property.
-	 * @param {HTMLElement} element
+	 * Apply the spec's `convert` hook, or pass the value through if none.
+	 * @param {*} value
+	 */
+	convert (value) {
+		let { convert } = this.spec;
+		return convert ? convert.call(this.element, value) : value;
+	}
+
+	/**
+	 * Apply a change descriptor by writing through the matching attribute or property.
+	 * Used to mirror a change after the fact (e.g. to replay queued changes).
 	 * @param {Object} change
 	 */
-	applyChange (element, change) {
-		if (change.source === "attribute") {
-			if (element.setAttribute) {
-				let attributeName = change.attributeName ?? this.spec.reflect.to;
-				let attributeValue =
-					change.attributeValue !== undefined
-						? change.attributeValue
-						: change.element.getAttribute(attributeName);
+	applyChange (change) {
+		let { element, spec } = this;
 
-				if (attributeValue === null) {
-					element.removeAttribute(attributeName);
-				}
-				else {
-					element.setAttribute(attributeName, attributeValue);
-				}
+		if (change.source === "attribute") {
+			let attributeName = change.attributeName ?? spec.reflect.to;
+			let attributeValue = change.attributeValue ?? element.getAttribute(attributeName);
+
+			if (attributeValue === null) {
+				element.removeAttribute(attributeName);
+			}
+			else {
+				element.setAttribute(attributeName, attributeValue);
 			}
 		}
 		else if (change.source === "property") {
 			element[this.name] = change.value;
 		}
 		else if (change.source === "default") {
-			// Value will be undefined here
-			if (change.element !== element) {
-				element[this.name] = change.element[this.name];
-			}
+			// Nothing to do: defaults resolve lazily on read.
 		}
 		else {
 			// Mixed
-			this.applyChange(element, { ...change, source: "attribute" });
-			this.applyChange(element, { ...change, source: "property" });
+			this.applyChange({ ...change, source: "attribute" });
+			this.applyChange({ ...change, source: "property" });
 		}
 	}
 
 	/**
-	 * Invoke the spec's `changed` hook and cascade to {@link Props#propChanged}.
-	 * @param {HTMLElement} element
+	 * Invoke the spec's `changed` hook and cascade to {@link ElementProps#propChanged}.
 	 * @param {Object} change
 	 */
-	async changed (element, change) {
-		this.spec.changed?.call(element, change);
-		this.props.propChanged(element, this, change);
+	changed (change) {
+		this.spec.changed?.call(this.element, change);
+		this.props.propChanged(this, change);
 	}
 
 	/**
 	 * Recalculate this prop's value (for computed props or `convert`) and store it.
-	 * @param {HTMLElement} element
-	 * @param {Prop} [dependency] The dependency whose change triggered this update.
+	 * @param {ElementProp} [dependency] The dependency whose change triggered this update.
 	 */
 	update (dependency) {
-		let element = this.element;
-		let oldValue = element.props[this.name];
+		let { spec } = this;
 
-		if (dependency === this.defaultProp) {
-			// We have no way of checking if the default prop has changed
-			// and there’s nothing to set, so let’s just called changed directly
-			this.changed(element, { element, source: "default" });
+		if (dependency && dependency.spec === spec.defaultProp) {
+			// The default prop changed; the resolved default may differ, but since
+			// we have no value of our own to update, just notify listeners.
+			this.changed({ source: "default" });
 			return;
 		}
 
-		if (this.spec.get) {
-			let value = this.spec.get.call(element);
-			this.set(element, value, { source: "get", oldValue });
+		if (spec.get) {
+			let value = spec.get.call(this.element);
+			this.set(value, { source: "get" });
 		}
 
-		if (this.spec.convert && oldValue !== undefined) {
-			let value = this.spec.convert.call(element, oldValue);
-			this.set(element, value, { source: "convert", oldValue });
+		if (spec.convert && this.value !== undefined) {
+			this.set(this.convert(this.value), { source: "convert" });
 		}
+	}
+
+	/**
+	 * Whether this prop currently depends on `dep`'s value.
+	 * Includes the default-prop link only while this prop has no explicit value.
+	 * @param {ElementProp} dep
+	 * @returns {boolean}
+	 */
+	dependsOn (dep) {
+		if (!dep) {
+			return false;
+		}
+
+		if (dep === this) {
+			return true;
+		}
+
+		let { spec } = this;
+		return (
+			spec.dependencies.has(dep.name) ||
+			(spec.defaultProp === dep.spec && this.value === undefined)
+		);
 	}
 }

--- a/src/plugins/props/util/ElementProp.js
+++ b/src/plugins/props/util/ElementProp.js
@@ -209,7 +209,8 @@ export default class ElementProp {
 	 * @param {HTMLElement} element
 	 * @param {Prop} [dependency] The dependency whose change triggered this update.
 	 */
-	update (element, dependency) {
+	update (dependency) {
+		let element = this.element;
 		let oldValue = element.props[this.name];
 
 		if (dependency === this.defaultProp) {

--- a/src/plugins/props/util/ElementProp.js
+++ b/src/plugins/props/util/ElementProp.js
@@ -44,21 +44,19 @@ export default class ElementProp {
 	 */
 	get () {
 		let element = this.element;
-		let value = element.props[this.name];
+		let value = this.value;
 
 		if (value === undefined) {
 			this.update(element);
-			value = element.props[this.name];
+			value = this.value;
 		}
 
 		if (value === undefined) {
-			if (this.default !== undefined) {
-				if (this.defaultProp) {
-					value = this.defaultProp.get(element);
-				}
-				else {
-					value = resolveValue(this.default, [element, element]);
-				}
+			if (this.defaultProp) {
+				value = this.defaultProp.get(element);
+			}
+			else if (this.default !== undefined) {
+				value = resolveValue(this.default, [element, element]);
 
 				try {
 					value = this.parse(value);

--- a/src/plugins/props/util/ElementProp.js
+++ b/src/plugins/props/util/ElementProp.js
@@ -160,12 +160,7 @@ export default class ElementProp {
 
 				let ignored = this.props.ignoredAttributes;
 				ignored.add(attributeName);
-				if (attributeValue === null) {
-					element.removeAttribute(attributeName);
-				}
-				else {
-					element.setAttribute(attributeName, attributeValue);
-				}
+				this.applyChange({ ...change, source: "attribute" });
 				ignored.delete(attributeName);
 			}
 		}

--- a/src/plugins/props/util/ElementProp.js
+++ b/src/plugins/props/util/ElementProp.js
@@ -1,0 +1,234 @@
+import { resolveValue } from "../util.js";
+
+export default class ElementProp {
+	/**
+	 * Internal value
+	 */
+	value;
+
+	/**
+	 *
+	 * @param {HTMLElement} element
+	 * @param {Prop} spec
+	 */
+	constructor (element, spec) {
+		this.element = element;
+		this.spec = spec;
+
+		let name = this.spec.name;
+		if (Object.hasOwn(element, name)) {
+			// A local data property will shadow the accessor that is defined on the prototype
+			// See https://github.com/nudeui/element/issues/14
+			let value = element[name];
+			delete element[name]; // Deleting the data property will uncover the accessor
+			element[name] = value; // Invoking the accessor means the value doesn't skip parsing
+		}
+		// TODO this needs editing
+		else if (element.props[name] === undefined && !this.spec.defaultProp) {
+			// Is not set and its default is not another prop
+			this.changed(element, { source: "default", element });
+		}
+	}
+
+	get name () {
+		return this.spec.name;
+	}
+
+	get type () {
+		return this.spec.type;
+	}
+
+	/**
+	 * Read this prop's current value for an element, falling back to its default.
+	 * @param {HTMLElement} element
+	 */
+	get () {
+		let element = this.element;
+		let value = element.props[this.name];
+
+		if (value === undefined) {
+			this.update(element);
+			value = element.props[this.name];
+		}
+
+		if (value === undefined) {
+			if (this.default !== undefined) {
+				if (this.defaultProp) {
+					value = this.defaultProp.get(element);
+				}
+				else {
+					value = resolveValue(this.default, [element, element]);
+				}
+
+				try {
+					value = this.parse(value);
+				}
+				catch (e) {
+					console.warn(
+						"Failed to parse default value",
+						value,
+						`for prop ${this.name}. Original error was: `,
+						e,
+					);
+					return null;
+				}
+
+				if (this.spec.convert) {
+					value = this.spec.convert.call(element, value);
+				}
+			}
+		}
+
+		return value;
+	}
+
+	/**
+	 * Write a value to an element: parse, convert, store, and reflect to attribute when applicable.
+	 * @param {HTMLElement} element
+	 * @param {*} value Raw value (string from an attribute, or any from a property write).
+	 * @param {{source?: string, name?: string, oldAttributeValue?: string | null}} [options]
+	 */
+	set (element, value, { source, name, oldAttributeValue } = {}) {
+		let oldValue = element.props[this.name];
+
+		let parsedValue;
+
+		try {
+			parsedValue = this.parse(value);
+		}
+		catch (e) {
+			// Abort mission
+			console.warn(
+				`Failed to parse value ${value} for prop ${this.name}. Original error was:`,
+				e,
+			);
+			return;
+		}
+
+		// removeAttribute() arrives as null; collapse to undefined so the prop
+		// reverts to its natural empty state. Property writes of null remain a
+		// legitimate user value.
+		if (source === "attribute" && parsedValue === null) {
+			parsedValue = undefined;
+		}
+
+		if (this.spec.convert) {
+			parsedValue = this.spec.convert.call(element, parsedValue);
+		}
+
+		if (this.equals(parsedValue, oldValue)) {
+			return;
+		}
+
+		element.props[this.name] = parsedValue;
+
+		let change = {
+			element,
+			source,
+			value: parsedValue,
+			oldValue,
+		};
+
+		if (source === "property") {
+			// Reflect to attribute?
+			if (this.spec.reflect.to) {
+				let attributeName = this.spec.reflect.to;
+				let attributeValue = this.stringify(parsedValue);
+				let oldAttributeValue = element.getAttribute(attributeName);
+
+				if (oldAttributeValue !== attributeValue) {
+					// TODO what if another prop is reflected *from* this attribute?
+					element.ignoredAttributes.add(attributeName);
+
+					Object.assign(change, { attributeName, attributeValue, oldAttributeValue });
+					this.applyChange(element, { ...change, source: "attribute" });
+
+					element.ignoredAttributes.delete(attributeName);
+				}
+			}
+		}
+		else if (source === "attribute") {
+			Object.assign(change, {
+				attributeName: name,
+				attributeValue: value,
+				oldAttributeValue,
+			});
+		}
+
+		this.changed(element, change);
+	}
+
+	/**
+	 * Apply a change descriptor to an element by writing through the matching attribute or property.
+	 * @param {HTMLElement} element
+	 * @param {Object} change
+	 */
+	applyChange (element, change) {
+		if (change.source === "attribute") {
+			if (element.setAttribute) {
+				let attributeName = change.attributeName ?? this.spec.reflect.to;
+				let attributeValue =
+					change.attributeValue !== undefined
+						? change.attributeValue
+						: change.element.getAttribute(attributeName);
+
+				if (attributeValue === null) {
+					element.removeAttribute(attributeName);
+				}
+				else {
+					element.setAttribute(attributeName, attributeValue);
+				}
+			}
+		}
+		else if (change.source === "property") {
+			element[this.name] = change.value;
+		}
+		else if (change.source === "default") {
+			// Value will be undefined here
+			if (change.element !== element) {
+				element[this.name] = change.element[this.name];
+			}
+		}
+		else {
+			// Mixed
+			this.applyChange(element, { ...change, source: "attribute" });
+			this.applyChange(element, { ...change, source: "property" });
+		}
+	}
+
+	/**
+	 * Invoke the spec's `changed` hook and cascade to {@link Props#propChanged}.
+	 * @param {HTMLElement} element
+	 * @param {Object} change
+	 */
+	async changed (element, change) {
+		this.spec.changed?.call(element, change);
+		this.props.propChanged(element, this, change);
+	}
+
+	/**
+	 * Recalculate this prop's value (for computed props or `convert`) and store it.
+	 * @param {HTMLElement} element
+	 * @param {Prop} [dependency] The dependency whose change triggered this update.
+	 */
+	update (element, dependency) {
+		let oldValue = element.props[this.name];
+
+		if (dependency === this.defaultProp) {
+			// We have no way of checking if the default prop has changed
+			// and there’s nothing to set, so let’s just called changed directly
+			this.changed(element, { element, source: "default" });
+			return;
+		}
+
+		if (this.spec.get) {
+			let value = this.spec.get.call(element);
+			this.set(element, value, { source: "get", oldValue });
+		}
+
+		if (this.spec.convert && oldValue !== undefined) {
+			let value = this.spec.convert.call(element, oldValue);
+			this.set(element, value, { source: "convert", oldValue });
+		}
+	}
+}

--- a/src/plugins/props/util/ElementProp.js
+++ b/src/plugins/props/util/ElementProp.js
@@ -80,7 +80,7 @@ export default class ElementProp {
 		let raw;
 
 		if (spec.defaultProp) {
-			raw = this.props.forSpec(spec.defaultProp).get();
+			raw = this.props.get(spec.defaultProp.name).get();
 		}
 		else if (spec.default !== undefined) {
 			raw = resolveValue(spec.default, [element, element]);

--- a/src/plugins/props/util/ElementProp.js
+++ b/src/plugins/props/util/ElementProp.js
@@ -194,7 +194,10 @@ export default class ElementProp {
 
 		if (change.source === "attribute") {
 			let attributeName = change.attributeName ?? spec.reflect.to;
-			let attributeValue = change.attributeValue ?? element.getAttribute(attributeName);
+			let attributeValue =
+				change.attributeValue !== undefined
+					? change.attributeValue
+					: element.getAttribute(attributeName);
 
 			if (attributeValue === null) {
 				element.removeAttribute(attributeName);

--- a/src/plugins/props/util/ElementProps.js
+++ b/src/plugins/props/util/ElementProps.js
@@ -1,0 +1,131 @@
+import ElementProp from "./ElementProp.js";
+import PropChangeEvent from "./PropChangeEvent.js";
+
+export default class ElementProps {
+	#paused = false;
+
+	/**
+	 * Per-element queue of propchange events awaiting dispatch while paused or before init.
+	 * @type {PropChangeEvent[]}
+	 */
+	eventDispatchQueue = [];
+
+	constructor (element) {
+		this.element = element;
+
+		// Update all reflected props from attributes at once
+		for (let name of this.observedAttributes) {
+			// Only process elements that have this attribute, or used to
+			if (element.hasAttribute(name)) {
+				this.attributeChanged(element, name);
+			}
+		}
+
+		// Fire propchange events for any props not already handled
+		for (let prop of this.values()) {
+			prop.initializeFor(element);
+		}
+
+		this.resumeEvents(element);
+	}
+
+	get spec () {
+		return this.element.constructor.props;
+	}
+
+	/**
+	 * Dispatch (or queue, if paused or not yet initialized) a propchange-style event.
+	 * @param {HTMLElement} element
+	 * @param {string} eventName
+	 * @param {{name: string, prop: Prop, detail: Object}} eventProps
+	 */
+	firePropChangeEvent (element, eventName, eventProps) {
+		let event = new PropChangeEvent(eventName, eventProps);
+
+		if (!this.#paused.has(element) && eventProps.prop.initialized) {
+			element.dispatchEvent?.(event);
+		}
+		else {
+			let queue = this.eventDispatchQueue ?? [];
+			queue.push(event);
+			this.eventDispatchQueue = queue;
+		}
+	}
+
+	/**
+	 * Hold propchange event dispatch for an element; events are queued and flushed on resume.
+	 * @param {HTMLElement} element
+	 */
+	pauseEvents () {
+		this.#paused = true;
+	}
+
+	/**
+	 * Resume propchange event dispatch for an element and flush any queued events.
+	 * @param {HTMLElement} element
+	 */
+	resumeEvents () {
+		this.#paused = false;
+
+		let queue = this.eventDispatchQueue;
+		if (!queue) {
+			return;
+		}
+
+		for (let event of queue) {
+			this.element.dispatchEvent?.(event);
+		}
+
+		this.eventDispatchQueue = [];
+	}
+
+	/**
+	 * Propagate an observed attribute change to every prop reflected from it.
+	 * @param {HTMLElement} element
+	 * @param {string} name Attribute name.
+	 * @param {string | null} [oldValue]
+	 */
+	attributeChanged (element, name, oldValue) {
+		if (!element.isConnected || element.ignoredAttributes.has(name)) {
+			// We process attributes all at once when the element is connected
+			return;
+		}
+
+		// Find relevant props
+		let propsFromAttribute = [...this.values()].filter(spec => spec.reflect.from === name);
+
+		for (let prop of propsFromAttribute) {
+			prop.set(element, element.getAttribute(name), {
+				source: "attribute",
+				name,
+				oldAttributeValue: oldValue,
+			});
+		}
+	}
+
+	/**
+	 * Fire propchange events for `prop` and cascade updates to any dependents.
+	 * @param {Prop} prop The prop that changed.
+	 * @param {Object} change Change descriptor (see {@link Prop#set}).
+	 */
+	propChanged (prop, change) {
+		// Source-first: fire before cascading so listeners hear the written prop first.
+		let eventNames = ["propchange", ...(prop.eventNames ?? [])];
+		for (let eventName of eventNames) {
+			this.firePropChangeEvent(this.element, eventName, {
+				name: prop.name,
+				prop,
+				detail: change,
+			});
+		}
+
+		// Update all props that have this prop as a dependency
+		let dependents = this.dependents[prop.name] ?? new Set();
+
+		for (let dependent of dependents) {
+			if (dependent.dependsOn(prop, this.element)) {
+				dependent.update(this.element, prop);
+			}
+		}
+	}
+}

--- a/src/plugins/props/util/ElementProps.js
+++ b/src/plugins/props/util/ElementProps.js
@@ -1,131 +1,166 @@
+import { symbols } from "xtensible";
 import ElementProp from "./ElementProp.js";
 import PropChangeEvent from "./PropChangeEvent.js";
 
-export default class ElementProps {
-	#paused = false;
+const { props } = symbols.known;
+
+/**
+ * Per-element collection of {@link ElementProp} wrappers.
+ * Owns per-element state: stored values, paused/queued events, and attribute
+ * echo suppression.
+ */
+export default class ElementProps extends Map {
+	#paused = true;
 
 	/**
-	 * Per-element queue of propchange events awaiting dispatch while paused or before init.
+	 * Attributes currently being written reflexively by an {@link ElementProp};
+	 * the resulting attributeChangedCallback should be ignored.
+	 * @type {Set<string>}
+	 */
+	ignoredAttributes = new Set();
+
+	/**
+	 * Queue of propchange-style events awaiting dispatch while paused.
 	 * @type {PropChangeEvent[]}
 	 */
-	eventDispatchQueue = [];
+	#eventQueue = [];
 
+	/**
+	 * Construct the per-element collection and run the mount-time init pass.
+	 * Pre-mount user writes (`element.foo = …`) and pre-mount attribute writes
+	 * (`setAttribute`) leave traces on the element itself — a shadowing data
+	 * property and an attribute, respectively — which each {@link ElementProp}'s
+	 * init pass picks up. So there's no separate `initialize()` step: the
+	 * constructor allocates every wrapper and then runs init on each.
+	 *
+	 * The split is internal (allocate-all → init-all) so cascades during init
+	 * always find existing wrappers in the Map — a wrapper materialized
+	 * mid-cascade would fire its own default event in addition to the
+	 * cascading update.
+	 *
+	 * @param {HTMLElement} element The element this collection belongs to.
+	 */
 	constructor (element) {
+		super();
 		this.element = element;
 
-		// Update all reflected props from attributes at once
-		for (let name of this.observedAttributes) {
-			// Only process elements that have this attribute, or used to
-			if (element.hasAttribute(name)) {
-				this.attributeChanged(element, name);
+		// Install on the element first, so mount-time events and computed
+		// getters fired during init can resolve other props through the
+		// accessor (which routes via `element.props`).
+		element.props = this;
+
+		// Materialize an ElementProp for every spec. Each constructor
+		// self-registers and runs its own init (shadow / attr / default-fire),
+		// cascading to dependents via {@link forSpec} if needed — so wrappers
+		// that get created mid-cascade end up in the Map before this loop
+		// reaches them.
+		this.spec.forEach(spec => this.forSpec(spec));
+
+		this.resumeEvents();
+	}
+
+	/**
+	 * @returns {Props} The class-level prop spec collection.
+	 */
+	get spec () {
+		return this.element.constructor[props];
+	}
+
+	/**
+	 * Get the {@link ElementProp} for an arbitrary {@link Prop} spec, creating
+	 * it lazily if absent. Used by accessors installed on a superclass prototype
+	 * so they find a wrapper even when the element's class-level Props doesn't
+	 * include that prop (inheritance).
+	 * @param {Prop} spec
+	 * @returns {ElementProp}
+	 */
+	forSpec (spec) {
+		// ElementProp's constructor self-registers, so `new` alone is enough.
+		return super.get(spec.name) ?? new ElementProp(this, spec);
+	}
+
+	/**
+	 * Propagate an observed attribute change to every prop reflected from it.
+	 * @param {string} name Attribute name.
+	 * @param {string | null} [oldValue]
+	 */
+	attributeChanged (name, oldValue) {
+		if (this.ignoredAttributes.has(name)) {
+			return;
+		}
+
+		for (let [propName, spec] of this.spec) {
+			if (spec.reflect.from === name) {
+				this.get(propName).set(this.element.getAttribute(name), {
+					source: "attribute",
+					name,
+					oldAttributeValue: oldValue,
+				});
 			}
 		}
-
-		// Fire propchange events for any props not already handled
-		for (let prop of this.values()) {
-			prop.initializeFor(element);
-		}
-
-		this.resumeEvents(element);
-	}
-
-	get spec () {
-		return this.element.constructor.props;
 	}
 
 	/**
-	 * Dispatch (or queue, if paused or not yet initialized) a propchange-style event.
-	 * @param {HTMLElement} element
-	 * @param {string} eventName
-	 * @param {{name: string, prop: Prop, detail: Object}} eventProps
+	 * Fire propchange events for `ep` and cascade updates to any dependents.
+	 * @param {ElementProp} ep The prop that changed.
+	 * @param {Object} change Change descriptor (see {@link ElementProp#set}).
 	 */
-	firePropChangeEvent (element, eventName, eventProps) {
-		let event = new PropChangeEvent(eventName, eventProps);
-
-		if (!this.#paused.has(element) && eventProps.prop.initialized) {
-			element.dispatchEvent?.(event);
+	propChanged (ep, change) {
+		// Source-first: fire before cascading so listeners hear the written prop first.
+		let eventNames = ["propchange", ...(ep.spec.eventNames ?? [])];
+		for (let eventName of eventNames) {
+			this.#firePropChangeEvent(eventName, {
+				name: ep.name,
+				prop: ep,
+				detail: change,
+			});
 		}
-		else {
-			let queue = this.eventDispatchQueue ?? [];
-			queue.push(event);
-			this.eventDispatchQueue = queue;
+
+		// Update all props that depend on this one. Use forSpec so a dependent
+		// that hasn't been materialized yet (e.g. during the constructor's
+		// initial iteration) gets created on demand.
+		let dependentSpecs = this.spec.dependents[ep.name] ?? [];
+		for (let depSpec of dependentSpecs) {
+			let dep = this.forSpec(depSpec);
+			if (dep.dependsOn(ep)) {
+				dep.update(ep);
+			}
 		}
 	}
 
 	/**
-	 * Hold propchange event dispatch for an element; events are queued and flushed on resume.
-	 * @param {HTMLElement} element
+	 * Hold propchange event dispatch; events fired in the meantime are queued.
 	 */
 	pauseEvents () {
 		this.#paused = true;
 	}
 
 	/**
-	 * Resume propchange event dispatch for an element and flush any queued events.
-	 * @param {HTMLElement} element
+	 * Resume propchange event dispatch and flush any queued events.
 	 */
 	resumeEvents () {
 		this.#paused = false;
 
-		let queue = this.eventDispatchQueue;
-		if (!queue) {
-			return;
-		}
-
+		let queue = this.#eventQueue;
+		this.#eventQueue = [];
 		for (let event of queue) {
-			this.element.dispatchEvent?.(event);
-		}
-
-		this.eventDispatchQueue = [];
-	}
-
-	/**
-	 * Propagate an observed attribute change to every prop reflected from it.
-	 * @param {HTMLElement} element
-	 * @param {string} name Attribute name.
-	 * @param {string | null} [oldValue]
-	 */
-	attributeChanged (element, name, oldValue) {
-		if (!element.isConnected || element.ignoredAttributes.has(name)) {
-			// We process attributes all at once when the element is connected
-			return;
-		}
-
-		// Find relevant props
-		let propsFromAttribute = [...this.values()].filter(spec => spec.reflect.from === name);
-
-		for (let prop of propsFromAttribute) {
-			prop.set(element, element.getAttribute(name), {
-				source: "attribute",
-				name,
-				oldAttributeValue: oldValue,
-			});
+			this.element.dispatchEvent(event);
 		}
 	}
 
 	/**
-	 * Fire propchange events for `prop` and cascade updates to any dependents.
-	 * @param {Prop} prop The prop that changed.
-	 * @param {Object} change Change descriptor (see {@link Prop#set}).
+	 * Dispatch (or queue, if paused) a propchange-style event.
+	 * @param {string} eventName
+	 * @param {{name: string, prop: ElementProp, detail: Object}} eventProps
 	 */
-	propChanged (prop, change) {
-		// Source-first: fire before cascading so listeners hear the written prop first.
-		let eventNames = ["propchange", ...(prop.eventNames ?? [])];
-		for (let eventName of eventNames) {
-			this.firePropChangeEvent(this.element, eventName, {
-				name: prop.name,
-				prop,
-				detail: change,
-			});
+	#firePropChangeEvent (eventName, eventProps) {
+		let event = new PropChangeEvent(eventName, eventProps);
+
+		if (this.#paused) {
+			this.#eventQueue.push(event);
 		}
-
-		// Update all props that have this prop as a dependency
-		let dependents = this.dependents[prop.name] ?? new Set();
-
-		for (let dependent of dependents) {
-			if (dependent.dependsOn(prop, this.element)) {
-				dependent.update(this.element, prop);
-			}
+		else {
+			this.element.dispatchEvent(event);
 		}
 	}
 }

--- a/src/plugins/props/util/ElementProps.js
+++ b/src/plugins/props/util/ElementProps.js
@@ -51,10 +51,12 @@ export default class ElementProps extends Map {
 
 		// Materialize an ElementProp for every spec. Each constructor
 		// self-registers and runs its own init (shadow / attr / default-fire),
-		// cascading to dependents via {@link forSpec} if needed — so wrappers
+		// cascading to dependents via {@link get} if needed — so wrappers
 		// that get created mid-cascade end up in the Map before this loop
 		// reaches them.
-		this.spec.forEach(spec => this.forSpec(spec));
+		for (let name of this.spec.keys()) {
+			this.get(name);
+		}
 
 		this.resumeEvents();
 	}
@@ -67,16 +69,24 @@ export default class ElementProps extends Map {
 	}
 
 	/**
-	 * Get the {@link ElementProp} for an arbitrary {@link Prop} spec, creating
-	 * it lazily if absent. Used by accessors installed on a superclass prototype
-	 * so they find a wrapper even when the element's class-level Props doesn't
-	 * include that prop (inheritance).
-	 * @param {Prop} spec
-	 * @returns {ElementProp}
+	 * Get the {@link ElementProp} wrapper for a prop by name, creating it on
+	 * demand from this element's own class-level {@link Props}.
+	 * @param {string} name
+	 * @returns {ElementProp | undefined}
 	 */
-	forSpec (spec) {
-		// ElementProp's constructor self-registers, so `new` alone is enough.
-		return super.get(spec.name) ?? new ElementProp(this, spec);
+	get (name) {
+		let ep = super.get(name);
+		if (ep) {
+			return ep;
+		}
+
+		let spec = this.spec.get(name);
+		if (spec) {
+			// ElementProp self-registers in our Map.
+			return new ElementProp(this, spec);
+		}
+
+		return undefined;
 	}
 
 	/**
@@ -116,12 +126,12 @@ export default class ElementProps extends Map {
 			});
 		}
 
-		// Update all props that depend on this one. Use forSpec so a dependent
-		// that hasn't been materialized yet (e.g. during the constructor's
-		// initial iteration) gets created on demand.
+		// Update all props that depend on this one. {@link get} materializes a
+		// dependent that hasn't been wrapped yet (e.g. during the constructor's
+		// initial iteration) on demand.
 		let dependentSpecs = this.spec.dependents[ep.name] ?? [];
 		for (let depSpec of dependentSpecs) {
-			let dep = this.forSpec(depSpec);
+			let dep = this.get(depSpec.name);
 			if (dep.dependsOn(ep)) {
 				dep.update(ep);
 			}

--- a/src/plugins/props/util/Prop.js
+++ b/src/plugins/props/util/Prop.js
@@ -33,7 +33,6 @@ let Self = class Prop {
 		this.enumerable = spec.enumerable ?? true;
 
 		this.default = spec.default;
-		this.defaultProp = spec.defaultProp ?? null;
 
 		if (spec.dependencies) {
 			this.dependencies = new Set(spec.dependencies);
@@ -66,6 +65,14 @@ let Self = class Prop {
 					return types[fnName](...args, this.type);
 				};
 		}
+	}
+
+	get defaultProp () {
+		if (typeof this.spec.defaultProp === "string") {
+			return this.props.get(this.spec.defaultProp);
+		}
+
+		return this.spec.defaultProp;
 	}
 
 	/**

--- a/src/plugins/props/util/Prop.js
+++ b/src/plugins/props/util/Prop.js
@@ -1,9 +1,13 @@
-import { inferDependencies, resolveValue, capitalize, isArrowFunction } from "../util.js";
+import { inferDependencies } from "../util.js";
 import * as types from "./types.js";
 
+/**
+ * Class-level metadata for a single prop.
+ * Holds the normalized spec; per-element state and behavior live in {@link ElementProp}.
+ */
 let Self = class Prop {
 	/**
-	 * @type {Props} props - The props object this prop belongs to
+	 * @type {Props} The owning {@link Props} collection.
 	 */
 	props;
 
@@ -18,11 +22,18 @@ let Self = class Prop {
 		}
 
 		this.name = name;
-		this.spec = spec;
 		this.props = props;
 
+		// Direct pass-through hooks: ElementProp accesses these via the Prop, never via a raw spec.
+		this.get = spec.get;
+		this.set = spec.set;
+		this.convert = spec.convert;
+		this.changed = spec.changed;
+		this.eventNames = spec.eventNames;
+		this.enumerable = spec.enumerable ?? true;
+
 		this.default = spec.default;
-		this.defaultProp = spec.defaultProp;
+		this.defaultProp = spec.defaultProp ?? null;
 
 		if (spec.dependencies) {
 			this.dependencies = new Set(spec.dependencies);
@@ -35,79 +46,76 @@ let Self = class Prop {
 			]);
 		}
 
-		// Normalize reflect config
-		// Computed properties are not reflected by default
-		this.reflect = spec.reflect ?? !this.spec.get;
-		if (typeof this.reflect === "boolean") {
-			this.reflect = { from: this.reflect, to: this.reflect };
+		// Normalize reflect config without mutating the user's spec.
+		// Computed properties are not reflected by default.
+		let reflect = spec.reflect ?? !spec.get;
+		if (typeof reflect !== "object" || reflect === null) {
+			reflect = { from: reflect, to: reflect };
 		}
-		this.reflect.from = this.reflect.from === true ? this.name : this.reflect.from || undefined;
-		this.reflect.to = this.reflect.to === true ? this.name : this.reflect.to || undefined;
+		this.reflect = {
+			from: reflect.from === true ? name : reflect.from || undefined,
+			to: reflect.to === true ? name : reflect.to || undefined,
+		};
 
 		this.type = types.resolve(spec.type);
 
 		for (let fnName of ["equals", "stringify", "parse"]) {
 			this[fnName] =
-				this.spec[fnName] ??
+				spec[fnName] ??
 				function (...args) {
 					return types[fnName](...args, this.type);
 				};
-		}
-
-		if (this.spec.convert) {
-			this.convert = this.spec.convert;
 		}
 	}
 
 	/**
 	 * Build the prototype accessor descriptor for this prop.
-	 * @param {{enumerable?: boolean}} [options]
+	 * Captures the Prop directly so subclass accessors keep working even when
+	 * the element's class-level {@link Props} doesn't include this prop
+	 * (inheritance) — the descriptor asks {@link ElementProps#forSpec} for
+	 * the matching wrapper without going through name lookup.
 	 * @returns {PropertyDescriptor}
 	 */
-	getDescriptor ({ enumerable = true } = this.spec) {
-		let me = this;
+	getDescriptor () {
+		let prop = this;
+		let { name, get: computed, set: userSet } = this;
 		let descriptor = {
 			get () {
-				return me.get(this);
+				// Pre-mount: this.props isn't set up yet, no data property
+				// shadowing has been written either, so the prop genuinely has
+				// no value to read.
+				return this.props?.forSpec(prop).get();
 			},
-			enumerable,
+			enumerable: this.enumerable,
 			configurable: true,
 		};
 
-		if (!this.spec.get || this.spec.set === true) {
+		if (!computed || userSet === true) {
 			descriptor.set = function (value) {
-				me.set(this, value, { source: "property" });
+				// TODO throw if this is the constructor class
+				if (this.props) {
+					this.props.forSpec(prop).set(value, { source: "property" });
+				}
+				else {
+					// Pre-mount write: install a shadowing data property. When
+					// ElementProps is later constructed, ElementProp#initialize
+					// will pick it up via shadow recovery (Object.hasOwn).
+					Object.defineProperty(this, name, {
+						value,
+						writable: true,
+						configurable: true,
+						enumerable: true,
+					});
+				}
 			};
 		}
-		else if (this.spec.set) {
+		else if (typeof userSet === "function") {
 			descriptor.set = function (value) {
-				me.spec.set.call(this, value);
+				userSet.call(this, value);
 			};
 		}
 
 		return descriptor;
-	}
-
-	/**
-	 * Whether this prop currently depends on `prop`'s value for the given element.
-	 * Includes the default-prop link only while this prop has no explicit value.
-	 * @param {Prop} prop
-	 * @param {HTMLElement} element
-	 * @returns {boolean}
-	 */
-	dependsOn (prop, element) {
-		if (!prop) {
-			return false;
-		}
-
-		if (prop === this) {
-			return true;
-		}
-
-		return (
-			this.dependencies.has(prop.name) ||
-			(this.defaultProp === prop && element.props[this.name] === undefined)
-		);
 	}
 };
 

--- a/src/plugins/props/util/Prop.js
+++ b/src/plugins/props/util/Prop.js
@@ -78,21 +78,19 @@ let Self = class Prop {
 
 	/**
 	 * Build the prototype accessor descriptor for this prop.
-	 * Captures the Prop directly so subclass accessors keep working even when
-	 * the element's class-level {@link Props} doesn't include this prop
-	 * (inheritance) — the descriptor asks {@link ElementProps#forSpec} for
-	 * the matching wrapper without going through name lookup.
+	 * Looks up the per-element wrapper by name; {@link ElementProps#get} walks
+	 * the class chain so accessors installed on a superclass prototype still
+	 * resolve to the parent's Prop when the subclass's Props doesn't include
+	 * the name (inheritance).
 	 * @returns {PropertyDescriptor}
 	 */
 	getDescriptor () {
-		let prop = this;
 		let { name, get: computed, set: userSet } = this;
 		let descriptor = {
 			get () {
-				// Pre-mount: this.props isn't set up yet, no data property
-				// shadowing has been written either, so the prop genuinely has
-				// no value to read.
-				return this.props?.forSpec(prop).get();
+				// `this.props` lazily materializes via the plugin's `provides`
+				// accessor on first access.
+				return this.props.get(name)?.get();
 			},
 			enumerable: this.enumerable,
 			configurable: true,
@@ -100,21 +98,7 @@ let Self = class Prop {
 
 		if (!computed || userSet === true) {
 			descriptor.set = function (value) {
-				// TODO throw if this is the constructor class
-				if (this.props) {
-					this.props.forSpec(prop).set(value, { source: "property" });
-				}
-				else {
-					// Pre-mount write: install a shadowing data property. When
-					// ElementProps is later constructed, ElementProp#initialize
-					// will pick it up via shadow recovery (Object.hasOwn).
-					Object.defineProperty(this, name, {
-						value,
-						writable: true,
-						configurable: true,
-						enumerable: true,
-					});
-				}
+				this.props.get(name)?.set(value, { source: "property" });
 			};
 		}
 		else if (typeof userSet === "function") {

--- a/src/plugins/props/util/Prop.js
+++ b/src/plugins/props/util/Prop.js
@@ -21,6 +21,7 @@ let Self = class Prop {
 			return spec;
 		}
 
+		this.spec = spec;
 		this.name = name;
 		this.props = props;
 

--- a/src/plugins/props/util/Prop.js
+++ b/src/plugins/props/util/Prop.js
@@ -117,9 +117,7 @@ let Self = class Prop {
 			};
 		}
 		else if (typeof userSet === "function") {
-			descriptor.set = function (value) {
-				userSet.call(this, value);
-			};
+			descriptor.set = userSet;
 		}
 
 		return descriptor;

--- a/src/plugins/props/util/Prop.js
+++ b/src/plugins/props/util/Prop.js
@@ -1,4 +1,4 @@
-import { inferDependencies, resolveValue, capitalize } from "../util.js";
+import { inferDependencies, resolveValue, capitalize, isArrowFunction } from "../util.js";
 import * as types from "./types.js";
 
 let Self = class Prop {
@@ -6,8 +6,6 @@ let Self = class Prop {
 	 * @type {Props} props - The props object this prop belongs to
 	 */
 	props;
-
-	#initialized = false;
 
 	/**
 	 * @param {string} name
@@ -23,29 +21,8 @@ let Self = class Prop {
 		this.spec = spec;
 		this.props = props;
 
-		this.type = types.resolve(spec.type);
-
 		this.default = spec.default;
-
-		if (typeof spec.default === "function") {
-			let defaultDependencies = spec.defaultDependencies ?? inferDependencies(spec.default);
-			if (defaultDependencies.length > 0) {
-				let defaultProp = "default" + capitalize(name);
-				this.props.add(defaultProp, {
-					get: spec.default,
-					dependencies: defaultDependencies,
-				});
-				this.default = this.props.get(defaultProp);
-			}
-		}
-
-		if (spec.defaultProp) {
-			Object.defineProperty(this, "default", {
-				get: () => this.props.get(spec.defaultProp),
-				configurable: true,
-				enumerable: true,
-			});
-		}
+		this.defaultProp = spec.defaultProp;
 
 		if (spec.dependencies) {
 			this.dependencies = new Set(spec.dependencies);
@@ -58,99 +35,28 @@ let Self = class Prop {
 			]);
 		}
 
+		// Normalize reflect config
 		// Computed properties are not reflected by default
 		this.reflect = spec.reflect ?? !this.spec.get;
-	}
+		if (typeof this.reflect === "boolean") {
+			this.reflect = { from: this.reflect, to: this.reflect };
+		}
+		this.reflect.from = this.reflect.from === true ? this.name : this.reflect.from || undefined;
+		this.reflect.to = this.reflect.to === true ? this.name : this.reflect.to || undefined;
 
-	/**
-	 * @returns {string | null} Attribute name this prop reflects from, or null if none.
-	 */
-	get fromAttribute () {
-		let reflectFrom = typeof this.reflect === "object" ? this.reflect.from : this.reflect;
-		return reflectFrom === true
-			? this.name
-			: typeof reflectFrom === "string"
-				? reflectFrom
-				: null;
-	}
+		this.type = types.resolve(spec.type);
 
-	/**
-	 * @returns {string | null} Attribute name this prop reflects to, or null if none.
-	 */
-	get toAttribute () {
-		let reflectTo = typeof this.reflect === "object" ? this.reflect.to : this.reflect;
-		return reflectTo === true ? this.name : typeof reflectTo === "string" ? reflectTo : null;
-	}
-
-	/**
-	 * @returns {Prop | null} The prop that provides this prop's default, if `default` is another prop.
-	 */
-	get defaultProp () {
-		return this.default instanceof Prop ? this.default : null;
-	}
-
-	/**
-	 * Compare two values for equality. Delegates to `spec.equals` if provided, else the prop's type.
-	 * @param {*} a
-	 * @param {*} b
-	 * @returns {boolean}
-	 */
-	equals (a, b) {
-		if (this.spec.equals) {
-			return this.spec.equals(a, b);
+		for (let fnName of ["equals", "stringify", "parse"]) {
+			this[fnName] =
+				this.spec[fnName] ??
+				function (...args) {
+					return types[fnName](...args, this.type);
+				};
 		}
 
-		return types.equals(a, b, this.type);
-	}
-
-	/**
-	 * Serialize a value for attribute reflection.
-	 * @param {*} value
-	 * @returns {string | null}
-	 */
-	stringify (value) {
-		if (this.spec.stringify) {
-			return this.spec.stringify(value);
+		if (this.spec.convert) {
+			this.convert = this.spec.convert;
 		}
-
-		return types.stringify(value, this.type);
-	}
-
-	/**
-	 * Parse a raw value into this prop's type. Input may be a string (from an attribute)
-	 * or any value (from a property write).
-	 * @param {*} value
-	 */
-	parse (value) {
-		if (this.spec.parse) {
-			return this.spec.parse(value);
-		}
-
-		return types.parse(value, this.type);
-	}
-
-	/**
-	 * Initialize this prop on an element: surface any pre-set value through the accessor,
-	 * or fire a default-source change if neither value nor default-prop applies.
-	 * @param {HTMLElement} element
-	 */
-	initializeFor (element) {
-		// Handle any properties already set before initialization
-		let name = this.name;
-
-		if (Object.hasOwn(element, name)) {
-			// A local data property will shadow the accessor that is defined on the prototype
-			// See https://github.com/nudeui/element/issues/14
-			let value = element[name];
-			delete element[name]; // Deleting the data property will uncover the accessor
-			element[name] = value; // Invoking the accessor means the value doesn't skip parsing
-		}
-		else if (element.props[name] === undefined && !this.defaultProp) {
-			// Is not set and its default is not another prop
-			this.changed(element, { source: "default", element });
-		}
-
-		this.#initialized = true;
 	}
 
 	/**
@@ -183,199 +89,6 @@ let Self = class Prop {
 	}
 
 	/**
-	 * Read this prop's current value for an element, falling back to its default.
-	 * @param {HTMLElement} element
-	 */
-	get (element) {
-		let value = element.props[this.name];
-
-		if (value === undefined) {
-			this.update(element);
-			value = element.props[this.name];
-		}
-
-		if (value === undefined) {
-			if (this.default !== undefined) {
-				if (this.defaultProp) {
-					value = this.defaultProp.get(element);
-				}
-				else {
-					value = resolveValue(this.default, [element, element]);
-				}
-
-				try {
-					value = this.parse(value);
-				}
-				catch (e) {
-					console.warn(
-						"Failed to parse default value",
-						value,
-						`for prop ${this.name}. Original error was: `,
-						e,
-					);
-					return null;
-				}
-
-				if (this.spec.convert) {
-					value = this.spec.convert.call(element, value);
-				}
-			}
-		}
-
-		return value;
-	}
-
-	/**
-	 * Write a value to an element: parse, convert, store, and reflect to attribute when applicable.
-	 * @param {HTMLElement} element
-	 * @param {*} value Raw value (string from an attribute, or any from a property write).
-	 * @param {{source?: string, name?: string, oldAttributeValue?: string | null}} [options]
-	 */
-	set (element, value, { source, name, oldAttributeValue } = {}) {
-		let oldValue = element.props[this.name];
-
-		let parsedValue;
-
-		try {
-			parsedValue = this.parse(value);
-		}
-		catch (e) {
-			// Abort mission
-			console.warn(
-				`Failed to parse value ${value} for prop ${this.name}. Original error was:`,
-				e,
-			);
-			return;
-		}
-
-		// removeAttribute() arrives as null; collapse to undefined so the prop
-		// reverts to its natural empty state. Property writes of null remain a
-		// legitimate user value.
-		if (source === "attribute" && parsedValue === null) {
-			parsedValue = undefined;
-		}
-
-		if (this.spec.convert) {
-			parsedValue = this.spec.convert.call(element, parsedValue);
-		}
-
-		if (this.equals(parsedValue, oldValue)) {
-			return;
-		}
-
-		element.props[this.name] = parsedValue;
-
-		let change = {
-			element,
-			source,
-			value: parsedValue,
-			oldValue,
-		};
-
-		if (source === "property") {
-			// Reflect to attribute?
-			if (this.toAttribute) {
-				let attributeName = this.toAttribute;
-				let attributeValue = this.stringify(parsedValue);
-				let oldAttributeValue = element.getAttribute(attributeName);
-
-				if (oldAttributeValue !== attributeValue) {
-					// TODO what if another prop is reflected *from* this attribute?
-					element.ignoredAttributes.add(this.toAttribute);
-
-					Object.assign(change, { attributeName, attributeValue, oldAttributeValue });
-					this.applyChange(element, { ...change, source: "attribute" });
-
-					element.ignoredAttributes.delete(attributeName);
-				}
-			}
-		}
-		else if (source === "attribute") {
-			Object.assign(change, {
-				attributeName: name,
-				attributeValue: value,
-				oldAttributeValue,
-			});
-		}
-
-		this.changed(element, change);
-	}
-
-	/**
-	 * Apply a change descriptor to an element by writing through the matching attribute or property.
-	 * @param {HTMLElement} element
-	 * @param {Object} change
-	 */
-	applyChange (element, change) {
-		if (change.source === "attribute") {
-			if (element.setAttribute) {
-				let attributeName = change.attributeName ?? this.toAttribute;
-				let attributeValue =
-					change.attributeValue !== undefined
-						? change.attributeValue
-						: change.element.getAttribute(attributeName);
-
-				if (attributeValue === null) {
-					element.removeAttribute(attributeName);
-				}
-				else {
-					element.setAttribute(attributeName, attributeValue);
-				}
-			}
-		}
-		else if (change.source === "property") {
-			element[this.name] = change.value;
-		}
-		else if (change.source === "default") {
-			// Value will be undefined here
-			if (change.element !== element) {
-				element[this.name] = change.element[this.name];
-			}
-		}
-		else {
-			// Mixed
-			this.applyChange(element, { ...change, source: "attribute" });
-			this.applyChange(element, { ...change, source: "property" });
-		}
-	}
-
-	/**
-	 * Invoke the spec's `changed` hook and cascade to {@link Props#propChanged}.
-	 * @param {HTMLElement} element
-	 * @param {Object} change
-	 */
-	async changed (element, change) {
-		this.spec.changed?.call(element, change);
-		this.props.propChanged(element, this, change);
-	}
-
-	/**
-	 * Recalculate this prop's value (for computed props or `convert`) and store it.
-	 * @param {HTMLElement} element
-	 * @param {Prop} [dependency] The dependency whose change triggered this update.
-	 */
-	update (element, dependency) {
-		let oldValue = element.props[this.name];
-
-		if (dependency === this.defaultProp) {
-			// We have no way of checking if the default prop has changed
-			// and there’s nothing to set, so let’s just called changed directly
-			this.changed(element, { element, source: "default" });
-			return;
-		}
-
-		if (this.spec.get) {
-			let value = this.spec.get.call(element);
-			this.set(element, value, { source: "get", oldValue });
-		}
-
-		if (this.spec.convert && oldValue !== undefined) {
-			let value = this.spec.convert.call(element, oldValue);
-			this.set(element, value, { source: "convert", oldValue });
-		}
-	}
-
-	/**
 	 * Whether this prop currently depends on `prop`'s value for the given element.
 	 * Includes the default-prop link only while this prop has no explicit value.
 	 * @param {Prop} prop
@@ -395,13 +108,6 @@ let Self = class Prop {
 			this.dependencies.has(prop.name) ||
 			(this.defaultProp === prop && element.props[this.name] === undefined)
 		);
-	}
-
-	/**
-	 * @returns {boolean} Whether {@link initializeFor} has run for this prop at least once.
-	 */
-	get initialized () {
-		return this.#initialized;
 	}
 };
 

--- a/src/plugins/props/util/Props.js
+++ b/src/plugins/props/util/Props.js
@@ -92,23 +92,9 @@ export default class Props extends Map {
 	}
 
 	/**
-	 * Resolve any `defaultProp: "name"` string references to actual {@link Prop} instances.
-	 * Done as a separate pass so a prop can reference another that hasn't been declared yet.
-	 */
-	#resolveDefaultProps () {
-		for (let prop of this.values()) {
-			if (typeof prop.defaultProp === "string") {
-				prop.defaultProp = this.get(prop.defaultProp);
-			}
-		}
-	}
-
-	/**
 	 * Rebuild the dependency graph and reorder props so dependents come after their dependencies.
 	 */
 	updateDependents () {
-		this.#resolveDefaultProps();
-
 		// Rebuild dependency graph
 		let dependents = {};
 

--- a/src/plugins/props/util/Props.js
+++ b/src/plugins/props/util/Props.js
@@ -1,25 +1,27 @@
-import { sortObject, isRegularFunction, capitalize } from "../util.js";
+import { sortObject, capitalize, inferDependencies } from "../util.js";
 import Prop from "./Prop.js";
 
+/**
+ * Class-level collection of {@link Prop} specs for a custom element class.
+ * Per-element state lives in {@link ElementProps}.
+ */
 export default class Props extends Map {
 	/**
-	 * Dependency graph
-	 * @type {Object.<string, Set<string>>}
-	 * Key is the name of the prop, value is a set of prop names that depend on it
+	 * Dependency graph.
+	 * Key is the name of the prop; value is the set of {@link Prop}s that depend on it.
+	 * @type {Object<string, Set<Prop>>}
 	 */
 	dependents = {};
 
 	/**
-	 *
-	 * @param {HTMLElement} Class The class to define props for
-	 * @param {Object} [props] The props to define as an object with the prop name as the key and the prop spec as the value.
+	 * @param {Function} Class The class to define props for.
+	 * @param {Object} [props] Props to define, as a map of name → spec.
 	 */
 	constructor (Class, props) {
 		super();
 
 		this.Class = Class;
 
-		// Define getters and setters for each prop
 		if (props) {
 			this.add(props);
 		}
@@ -29,7 +31,7 @@ export default class Props extends Map {
 	 * @returns {string[]} Unique attribute names that any reflected prop reads from.
 	 */
 	get observedAttributes () {
-		let attributes = [...this.values()].map(spec => spec.reflect.from).filter(Boolean);
+		let attributes = [...this.values()].map(prop => prop.reflect.from).filter(Boolean);
 		return [...new Set(attributes)];
 	}
 
@@ -37,34 +39,50 @@ export default class Props extends Map {
 	 * Define one or more props on the class.
 	 * @param {string | Object<string, Object>} nameOrProps Prop name, or map of name → spec.
 	 * @param {Object} [spec] Prop spec, when the first argument is a name.
+	 * @returns {Prop | Prop[]} The created prop, or array of created props.
 	 */
-	add (props) {
-		if (arguments.length === 2) {
-			let [name, spec] = arguments;
-			return this.add({ [name]: spec });
+	add (nameOrProps, spec) {
+		if (typeof nameOrProps === "string") {
+			let prop = this.createProp(nameOrProps, spec);
+			this.updateDependents();
+			return prop;
 		}
 
-		for (let [name, spec] of Object.entries(props)) {
-			this.createProp(name, spec);
+		let created = [];
+		for (let [name, spec] of Object.entries(nameOrProps)) {
+			created.push(this.createProp(name, spec));
 		}
 
 		this.updateDependents();
+		return created;
 	}
 
 	/**
-	 * Low level method to create one prop. Does not call updateDependents()
+	 * Low-level: create a single prop and install its accessor on the class prototype.
+	 * Does not call {@link updateDependents}; callers should batch and call it once.
+	 * Clones `spec` before any normalization so the user's object is not mutated.
 	 * @param {string} name
 	 * @param {Object} spec
-	 * @returns
+	 * @returns {Prop}
 	 */
 	createProp (name, spec) {
-		if (isRegularFunction(spec.default) && !("defaultProp" in spec)) {
-			// Create a prop for the default value so that dependencies are tracked and change events are fired for it
-			delete spec.default;
-			spec.defaultProp = this.createProp("default" + capitalize(name), {
-				get: spec.default,
-			});
-			// No need to call updateDependents() here, it will be called anyway at the end of this
+		spec = { ...spec };
+
+		// Promote `default () { ... }` to a synthetic computed prop so its
+		// dependencies are tracked and changes are propagated. A function default
+		// with no `this.X` references behaves like a constant and stays as the
+		// plain default (this also covers arrow functions, which we can't
+		// reliably tell apart from regular ones).
+		if (typeof spec.default === "function" && !spec.defaultProp) {
+			let defaultDependencies = spec.defaultDependencies ?? inferDependencies(spec.default);
+			if (defaultDependencies.length > 0) {
+				let defaultFn = spec.default;
+				delete spec.default;
+				spec.defaultProp = this.createProp("default" + capitalize(name), {
+					get: defaultFn,
+					dependencies: defaultDependencies,
+				});
+			}
 		}
 
 		let prop = new Prop(name, spec, this);
@@ -74,9 +92,23 @@ export default class Props extends Map {
 	}
 
 	/**
+	 * Resolve any `defaultProp: "name"` string references to actual {@link Prop} instances.
+	 * Done as a separate pass so a prop can reference another that hasn't been declared yet.
+	 */
+	#resolveDefaultProps () {
+		for (let prop of this.values()) {
+			if (typeof prop.defaultProp === "string") {
+				prop.defaultProp = this.get(prop.defaultProp);
+			}
+		}
+	}
+
+	/**
 	 * Rebuild the dependency graph and reorder props so dependents come after their dependencies.
 	 */
 	updateDependents () {
+		this.#resolveDefaultProps();
+
 		// Rebuild dependency graph
 		let dependents = {};
 

--- a/src/plugins/props/util/Props.js
+++ b/src/plugins/props/util/Props.js
@@ -46,12 +46,17 @@ export default class Props extends Map {
 		}
 
 		for (let [name, spec] of Object.entries(props)) {
-			let prop = new Prop(name, spec, this);
-			this.set(name, prop);
-			Object.defineProperty(this.Class.prototype, name, prop.getDescriptor());
+			this.createProp(name, spec);
 		}
 
 		this.updateDependents();
+	}
+
+	createProp (name, spec) {
+		let prop = new Prop(name, spec, this);
+		this.set(name, prop);
+		Object.defineProperty(this.Class.prototype, name, prop.getDescriptor());
+		return prop;
 	}
 
 	/**

--- a/src/plugins/props/util/Props.js
+++ b/src/plugins/props/util/Props.js
@@ -1,6 +1,5 @@
-import { sortObject } from "../util.js";
+import { sortObject, isRegularFunction, capitalize } from "../util.js";
 import Prop from "./Prop.js";
-import PropChangeEvent from "./PropChangeEvent.js";
 
 export default class Props extends Map {
 	/**
@@ -30,7 +29,7 @@ export default class Props extends Map {
 	 * @returns {string[]} Unique attribute names that any reflected prop reads from.
 	 */
 	get observedAttributes () {
-		let attributes = [...this.values()].map(spec => spec.fromAttribute).filter(Boolean);
+		let attributes = [...this.values()].map(spec => spec.reflect.from).filter(Boolean);
 		return [...new Set(attributes)];
 	}
 
@@ -52,7 +51,22 @@ export default class Props extends Map {
 		this.updateDependents();
 	}
 
+	/**
+	 * Low level method to create one prop. Does not call updateDependents()
+	 * @param {string} name
+	 * @param {Object} spec
+	 * @returns
+	 */
 	createProp (name, spec) {
+		if (isRegularFunction(spec.default) && !("defaultProp" in spec)) {
+			// Create a prop for the default value so that dependencies are tracked and change events are fired for it
+			delete spec.default;
+			spec.defaultProp = this.createProp("default" + capitalize(name), {
+				get: spec.default,
+			});
+			// No need to call updateDependents() here, it will be called anyway at the end of this
+		}
+
 		let prop = new Prop(name, spec, this);
 		this.set(name, prop);
 		Object.defineProperty(this.Class.prototype, name, prop.getDescriptor());
@@ -137,138 +151,5 @@ export default class Props extends Map {
 				this.dependents[name] = new Set(props);
 			}
 		}
-	}
-
-	/**
-	 * Propagate an observed attribute change to every prop reflected from it.
-	 * @param {HTMLElement} element
-	 * @param {string} name Attribute name.
-	 * @param {string | null} [oldValue]
-	 */
-	attributeChanged (element, name, oldValue) {
-		if (!element.isConnected || element.ignoredAttributes.has(name)) {
-			// We process attributes all at once when the element is connected
-			return;
-		}
-
-		// Find relevant props
-		let propsFromAttribute = [...this.values()].filter(spec => spec.fromAttribute === name);
-
-		for (let prop of propsFromAttribute) {
-			prop.set(element, element.getAttribute(name), {
-				source: "attribute",
-				name,
-				oldAttributeValue: oldValue,
-			});
-		}
-	}
-
-	/**
-	 * Elements currently holding propchange event dispatch.
-	 * @type {WeakSet<HTMLElement>}
-	 */
-	#paused = new WeakSet();
-
-	/**
-	 * Per-element queue of propchange events awaiting dispatch while paused or before init.
-	 * @type {WeakMap<HTMLElement, PropChangeEvent[]>}
-	 */
-	eventDispatchQueue = new WeakMap();
-
-	/**
-	 * Fire propchange events for `prop` and cascade updates to any dependents.
-	 * @param {HTMLElement} element
-	 * @param {Prop} prop The prop that changed.
-	 * @param {Object} change Change descriptor (see {@link Prop#set}).
-	 */
-	propChanged (element, prop, change) {
-		// Source-first: fire before cascading so listeners hear the written prop first.
-		let eventNames = ["propchange", ...(prop.eventNames ?? [])];
-		for (let eventName of eventNames) {
-			this.firePropChangeEvent(element, eventName, {
-				name: prop.name,
-				prop,
-				detail: change,
-			});
-		}
-
-		// Update all props that have this prop as a dependency
-		let dependents = this.dependents[prop.name] ?? new Set();
-
-		for (let dependent of dependents) {
-			if (dependent.dependsOn(prop, element)) {
-				dependent.update(element, prop);
-			}
-		}
-	}
-
-	/**
-	 * Dispatch (or queue, if paused or not yet initialized) a propchange-style event.
-	 * @param {HTMLElement} element
-	 * @param {string} eventName
-	 * @param {{name: string, prop: Prop, detail: Object}} eventProps
-	 */
-	firePropChangeEvent (element, eventName, eventProps) {
-		let event = new PropChangeEvent(eventName, eventProps);
-
-		if (!this.#paused.has(element) && eventProps.prop.initialized) {
-			element.dispatchEvent?.(event);
-		}
-		else {
-			let queue = this.eventDispatchQueue.get(element) ?? [];
-			queue.push(event);
-			this.eventDispatchQueue.set(element, queue);
-		}
-	}
-
-	/**
-	 * Initialize all props for an element: read reflected attributes, apply defaults,
-	 * and flush any queued events.
-	 * @param {HTMLElement} element
-	 */
-	initializeFor (element) {
-		if (element.hasAttribute) {
-			// Update all reflected props from attributes at once
-			for (let name of this.observedAttributes) {
-				// Only process elements that have this attribute, or used to
-				if (element.hasAttribute(name)) {
-					this.attributeChanged(element, name);
-				}
-			}
-		}
-
-		// Fire propchange events for any props not already handled
-		for (let prop of this.values()) {
-			prop.initializeFor(element);
-		}
-
-		this.resumeEvents(element);
-	}
-
-	/**
-	 * Hold propchange event dispatch for an element; events are queued and flushed on resume.
-	 * @param {HTMLElement} element
-	 */
-	pauseEvents (element) {
-		this.#paused.add(element);
-	}
-
-	/**
-	 * Resume propchange event dispatch for an element and flush any queued events.
-	 * @param {HTMLElement} element
-	 */
-	resumeEvents (element) {
-		this.#paused.delete(element);
-
-		let queue = this.eventDispatchQueue.get(element);
-		if (!queue) {
-			return;
-		}
-
-		for (let event of queue) {
-			element.dispatchEvent?.(event);
-		}
-
-		this.eventDispatchQueue.delete(element);
 	}
 }

--- a/src/plugins/props/util/Props.js
+++ b/src/plugins/props/util/Props.js
@@ -1,6 +1,9 @@
+import { symbols } from "xtensible";
+import { getSuper } from "xtensible/util";
 import { sortObject, capitalize, inferDependencies } from "../util.js";
 import Prop from "./Prop.js";
 
+export const { props } = symbols.known;
 /**
  * Class-level collection of {@link Prop} specs for a custom element class.
  * Per-element state lives in {@link ElementProps}.
@@ -13,26 +16,46 @@ export default class Props extends Map {
 	 */
 	dependents = {};
 
+	parent = null;
+
 	/**
 	 * @param {Function} Class The class to define props for.
-	 * @param {Object} [props] Props to define, as a map of name → spec.
+	 * @param {Object} [specs] Props to define, as a map of name → spec.
 	 */
-	constructor (Class, props) {
+	constructor (Class, specs) {
 		super();
 
 		this.Class = Class;
 
-		if (props) {
-			this.add(props);
+		this.parent = getSuper(Class)?.[props] ?? null;
+
+		if (specs) {
+			this.add(specs);
 		}
 	}
 
-	/**
-	 * @returns {string[]} Unique attribute names that any reflected prop reads from.
-	 */
-	get observedAttributes () {
-		let attributes = [...this.values()].map(prop => prop.reflect.from).filter(Boolean);
-		return [...new Set(attributes)];
+	has (name) {
+		return super.has(name) || this.parent?.has(name);
+	}
+
+	get (name) {
+		return super.get(name) ?? this.parent?.get(name);
+	}
+
+	*allValues () {
+		if (this.parent) {
+			yield* this.parent.allValues();
+		}
+
+		yield* super.values();
+	}
+
+	*allKeys () {
+		if (this.parent) {
+			yield* this.parent.allKeys();
+		}
+
+		yield* super.keys();
 	}
 
 	/**

--- a/test/Prop.js
+++ b/test/Prop.js
@@ -132,10 +132,9 @@ export default {
 
 						let props = new Props(Class, Class.props);
 
-						let ret = props.get("foo").default;
-						if (ret instanceof Prop) {
-							ret = ret.default;
-						}
+						let prop = props.get("foo");
+						// Follow `defaultProp` chain to find the underlying default value.
+						let ret = prop.defaultProp ? prop.defaultProp.default : prop.default;
 
 						return resolveValue(ret, []);
 					},
@@ -190,51 +189,31 @@ export default {
 					],
 				},
 				{
-					name: "Reflections",
+					name: "reflect",
+					description: "Normalized {from, to} attribute names for each spec shape.",
 					run (spec) {
 						let prop = new Prop("foo", spec);
-						return prop.reflect;
+						return [prop.reflect.from, prop.reflect.to];
 					},
 					tests: [
 						{
 							name: "By default, props are reflected",
 							arg: {},
-							expect: true,
-						},
-						{
-							name: "Disable reflection",
-							arg: {
-								reflect: false,
-							},
-							expect: false,
+							expect: ["foo", "foo"],
 						},
 						{
 							name: "Computed props are not reflected by default",
 							arg: {
 								get () {},
 							},
-							expect: false,
+							expect: [undefined, undefined],
 						},
 						{
-							name: "Reflected computed prop",
+							name: "Computed props can opt back in",
 							arg: {
 								get () {},
 								reflect: true,
 							},
-							expect: true,
-						},
-					],
-				},
-				{
-					name: "fromAttribute() / toAttribute()",
-					run (spec) {
-						let prop = new Prop("foo", spec);
-						return [prop.fromAttribute, prop.toAttribute];
-					},
-					tests: [
-						{
-							name: "By default, props are reflected",
-							arg: {},
 							expect: ["foo", "foo"],
 						},
 						{
@@ -247,7 +226,7 @@ export default {
 							arg: {
 								reflect: false,
 							},
-							expect: [null, null],
+							expect: [undefined, undefined],
 						},
 						{
 							arg: {
@@ -279,7 +258,7 @@ export default {
 									from: "bar",
 								},
 							},
-							expect: ["bar", null],
+							expect: ["bar", undefined],
 						},
 						{
 							arg: {
@@ -287,7 +266,7 @@ export default {
 									to: "baz",
 								},
 							},
-							expect: [null, "baz"],
+							expect: [undefined, "baz"],
 						},
 						{
 							arg: {
@@ -295,7 +274,7 @@ export default {
 									from: true,
 								},
 							},
-							expect: ["foo", null],
+							expect: ["foo", undefined],
 						},
 						{
 							arg: {
@@ -303,7 +282,7 @@ export default {
 									to: true,
 								},
 							},
-							expect: [null, "foo"],
+							expect: [undefined, "foo"],
 						},
 						{
 							arg: {
@@ -311,7 +290,7 @@ export default {
 									from: false,
 								},
 							},
-							expect: [null, null],
+							expect: [undefined, undefined],
 						},
 						{
 							arg: {
@@ -319,7 +298,7 @@ export default {
 									to: false,
 								},
 							},
-							expect: [null, null],
+							expect: [undefined, undefined],
 						},
 						{
 							arg: {
@@ -346,7 +325,7 @@ export default {
 									to: "baz",
 								},
 							},
-							expect: [null, "baz"],
+							expect: [undefined, "baz"],
 						},
 						{
 							arg: {
@@ -355,7 +334,7 @@ export default {
 									to: false,
 								},
 							},
-							expect: ["bar", null],
+							expect: ["bar", undefined],
 						},
 						{
 							arg: {
@@ -364,7 +343,7 @@ export default {
 									to: false,
 								},
 							},
-							expect: [null, null],
+							expect: [undefined, undefined],
 						},
 						{
 							arg: {
@@ -382,7 +361,7 @@ export default {
 									to: false,
 								},
 							},
-							expect: ["foo", null],
+							expect: ["foo", undefined],
 						},
 						{
 							arg: {
@@ -391,7 +370,7 @@ export default {
 									to: true,
 								},
 							},
-							expect: [null, "foo"],
+							expect: [undefined, "foo"],
 						},
 					],
 				},

--- a/test/Props.js
+++ b/test/Props.js
@@ -42,50 +42,5 @@ export default {
 				},
 			],
 		},
-		{
-			name: "observedAttributes()",
-			run (Class) {
-				let props = new Props(Class, Class.props);
-				return props.observedAttributes;
-			},
-			tests: [
-				{
-					name: "No props === no observed attributes",
-					arg: class {
-						static props = {};
-					},
-					expect: [],
-				},
-				{
-					name: "Observed attributes correspond to reflected props",
-					arg: class {
-						static props = {
-							foo: {},
-							bar: {
-								reflect: false,
-							},
-							baz: {
-								reflect: { from: "yolo" },
-							},
-							foobar: {
-								reflect: "foo",
-							},
-						};
-					},
-					expect: ["foo", "yolo"],
-				},
-				{
-					name: "Props reflecting from an empty string should be ignored",
-					arg: class {
-						static props = {
-							foo: {
-								reflect: "",
-							},
-						};
-					},
-					expect: [],
-				},
-			],
-		},
 	],
 };

--- a/test/plugins/props/index.js
+++ b/test/plugins/props/index.js
@@ -7,6 +7,7 @@ import propchange from "./propchange.js";
 import lifecycle from "./lifecycle.js";
 import inheritance from "./inheritance.js";
 import install from "./install.js";
+import observedAttributes from "./observed-attributes.js";
 
 export default {
 	name: "Props plugin",
@@ -43,5 +44,6 @@ export default {
 		},
 		inheritance,
 		install,
+		observedAttributes,
 	],
 };

--- a/test/plugins/props/inheritance.js
+++ b/test/plugins/props/inheritance.js
@@ -1,12 +1,14 @@
-// import { restoreNativeCustomEvent } from "../../util/happy-dom.js";
+import { restoreNativeCustomEvent } from "../../util/happy-dom.js";
 import ElementFactory from "../../../src/element/factory.js";
 import { default as propsPlugin, props } from "../../../src/plugins/props/index.js";
 
-// restoreNativeCustomEvent();
+restoreNativeCustomEvent();
+
+let i = 0;
 
 export default {
 	name: "Inheritance",
-	beforeAll () {
+	beforeEach () {
 		class ParentElement extends ElementFactory(HTMLElement, [propsPlugin]) {
 			static props = {
 				parentOnly: { type: Number },
@@ -66,11 +68,11 @@ export default {
 			name: "Child inherits, overrides, and adds props",
 			description:
 				"Combines the #104 baseline (parent prop installs) with the override rule (child wins when both classes declare the same prop).",
-			beforeAll () {
-				this.parent.beforeAll.call(this);
+			beforeEach () {
+				this.parent.parent.beforeEach.call(this);
 				let { ParentElement, ChildElement } = this.data;
 
-				let tag = "nude-element-parent-props";
+				let tag = `nude-element-parent-props-${i++}`;
 				customElements.define(tag, ChildElement);
 				this.data.childElement = document.body.appendChild(document.createElement(tag));
 			},

--- a/test/plugins/props/inheritance.js
+++ b/test/plugins/props/inheritance.js
@@ -1,49 +1,97 @@
+// import { restoreNativeCustomEvent } from "../../util/happy-dom.js";
 import ElementFactory from "../../../src/element/factory.js";
-import { default as propsPlugin } from "../../../src/plugins/props/index.js";
+import { default as propsPlugin, props } from "../../../src/plugins/props/index.js";
+
+// restoreNativeCustomEvent();
 
 export default {
 	name: "Inheritance",
+	beforeAll () {
+		class ParentElement extends ElementFactory(HTMLElement, [propsPlugin]) {
+			static props = {
+				parentOnly: { type: Number },
+				overridden: { default: "5" },
+			};
+		}
+		class ChildElement extends ParentElement {
+			static props = {
+				childOnly: { type: Number },
+				overridden: { type: Number },
+			};
+		}
+		ParentElement.setup();
+		ChildElement.setup();
+
+		Object.assign(this.data, { ParentElement, ChildElement });
+	},
+	data: {},
 
 	tests: [
+		{
+			name: "Parent class gets its own Props, linked from Child via `parent`",
+			description:
+				"When a Child class with `static props` extends a Parent that also " +
+				"declares `static props`, instantiating Child triggers Parent's Props " +
+				"creation (via the setup hook chain), populates it with Parent's " +
+				"declared props, and Child[props].parent references it.",
+			expect: true,
+			tests: [
+				{
+					name: "Parent class has a Props instance",
+					run () {
+						return Boolean(this.data.ParentElement[props]);
+					},
+				},
+				{
+					name: "Parent Props instance is different from Child's",
+					run () {
+						return this.data.ParentElement[props] !== this.data.ChildElement[props];
+					},
+				},
+				{
+					name: "Parent class's Props includes its declared prop",
+					run () {
+						return this.data.ParentElement[props].has("parentOnly");
+					},
+				},
+				{
+					name: "Child class's Props includes its declared prop",
+					run () {
+						return this.data.ChildElement[props].has("childOnly");
+					},
+				},
+			],
+		},
 		{
 			name: "Child inherits, overrides, and adds props",
 			description:
 				"Combines the #104 baseline (parent prop installs) with the override rule (child wins when both classes declare the same prop).",
-			run () {
-				let Parent = class extends ElementFactory(HTMLElement, [propsPlugin]) {
-					static props = {
-						inherited: { type: Number },
-						shared: { type: Number },
-					};
-				};
-				let Child = class extends Parent {
-					static props = {
-						shared: { type: String },
-						own: { type: Number },
-					};
-				};
+			beforeAll () {
+				this.parent.beforeAll.call(this);
+				let { ParentElement, ChildElement } = this.data;
 
-				let tag = "nude-element-hierarchy";
-				customElements.define(tag, Child);
-
-				let element = document.createElement(tag);
-				document.body.append(element);
-
-				element.inherited = "3";
-				element.shared = "5";
-				element.own = "7";
-
-				return {
-					inherited: element.inherited,
-					shared: element.shared,
-					own: element.own,
-				};
+				let tag = "nude-element-parent-props";
+				customElements.define(tag, ChildElement);
+				this.data.childElement = document.body.appendChild(document.createElement(tag));
 			},
-			expect: {
-				inherited: 3,
-				shared: "5",
-				own: 7,
+			run (prop, value) {
+				this.data.childElement[prop] = value;
+				return this.data.childElement[prop];
 			},
+			tests: [
+				{
+					args: ["parentOnly", "3"],
+					expect: 3,
+				},
+				{
+					args: ["overridden", "5"],
+					expect: 5,
+				},
+				{
+					args: ["childOnly", "7"],
+					expect: 7,
+				},
+			],
 		},
 	],
 };

--- a/test/plugins/props/install.js
+++ b/test/plugins/props/install.js
@@ -42,5 +42,42 @@ export default {
 				derived: "hello/42",
 			},
 		},
+		{
+			name: "Computed reading a sibling during mount sees its parsed value, not a raw pre-mount write",
+			description:
+				"`derived` cascades from `trigger`'s init; it must read `items` through the accessor " +
+				"(parse: \"x,y,z\" → array), not the still-shadowing pre-mount own data property.",
+			run () {
+				let observed;
+
+				let tag = defineElement({
+					plugins: [propsPlugin],
+					props: {
+						trigger: { type: Number },
+						items: {
+							parse: value => (typeof value === "string" ? value.split(",") : value),
+						},
+						derived: {
+							get () {
+								if (this.trigger !== undefined) {
+									observed ??= this.items;
+								}
+
+								return observed;
+							},
+						},
+					},
+				});
+
+				let element = document.createElement(tag);
+				element.trigger = 1;
+				element.items = "x,y,z";
+				document.body.append(element);
+
+				element.remove();
+				return observed;
+			},
+			expect: ["x", "y", "z"],
+		},
 	],
 };

--- a/test/plugins/props/lifecycle.js
+++ b/test/plugins/props/lifecycle.js
@@ -1,5 +1,3 @@
-import { props as propsSymbol } from "../../../src/plugins/props/index.js";
-
 export default {
 	name: "Disconnect / reconnect lifecycle",
 
@@ -38,14 +36,13 @@ export default {
 				element.a = 1; // fires immediately
 				let beforePause = log.length;
 
-				let props = element.constructor[propsSymbol];
-				props.pauseEvents(element);
+				element.props.pauseEvents();
 
 				element.b = "x";
 				element.a = 2;
 
 				let duringPause = log.length - beforePause;
-				props.resumeEvents(element);
+				element.props.resumeEvents();
 
 				return { duringPause, afterResume: log };
 			},

--- a/test/plugins/props/observed-attributes.js
+++ b/test/plugins/props/observed-attributes.js
@@ -1,0 +1,42 @@
+import { default as propsPlugin } from "../../../src/plugins/props/index.js";
+import { defineElement } from "../../util/dom.js";
+
+export default {
+	name: "observedAttributes",
+	run (props) {
+		let tag = defineElement({ plugins: [propsPlugin], props });
+		return customElements.get(tag).observedAttributes;
+	},
+	tests: [
+		{
+			name: "No props === no observed attributes",
+			arg: {},
+			expect: [],
+		},
+		{
+			name: "Observed attributes correspond to reflected props",
+			arg: {
+				foo: {},
+				bar: {
+					reflect: false,
+				},
+				baz: {
+					reflect: { from: "yolo" },
+				},
+				foobar: {
+					reflect: "foo",
+				},
+			},
+			expect: ["foo", "yolo"],
+		},
+		{
+			name: "Props reflecting from an empty string should be ignored",
+			arg: {
+				foo: {
+					reflect: "",
+				},
+			},
+			expect: [],
+		},
+	],
+};


### PR DESCRIPTION
## Summary

Splits `Prop` / `Props` (class-level metadata) from new `ElementProp` / `ElementProps` (per-element state and behavior). `element.props` becomes an `ElementProps` instance — a `Map<string, ElementProp>` — installed by the `constructed` hook.

- `Prop` exposes normalized fields (`reflect.{from,to}`, `dependencies`, `type`) and direct refs to hook fns. Descriptor captures the `Prop` directly so inherited prop accessors keep working.
- `ElementProp` self-registers in its `ElementProps` and runs shadow recovery / attr-read / default-fire inline in its constructor. Default-fire is gated on `!defaultProp && !spec.get` so computed and `defaultProp`'d props don't double-fire — they get their initial value via the cascade from their dependencies.
- `ElementProps` self-installs on `element.props` first thing in its constructor, then materializes wrappers via idempotent `forSpec(spec)`.
- Pre-mount property writes install a shadowing data property which the `ElementProp` constructor picks up via `Object.hasOwn`; pre-mount attribute writes are read by the same constructor's attr branch.

## Behavior changes

- `event.detail.element` removed (use `event.target`).
- `event.prop` is now the `ElementProp` instance (was the class-level `Prop`).
- `element.props` is the `ElementProps` Map (was a plain `{}` bag).
- `element.ignoredAttributes` moves into `ElementProps` as an internal field.

## Test plan
- [x] `npm test` — 96/100 pass, 4 skipped (parity with baseline)