### PR TITLE
Handle escaped separators in split()

### DIFF
--- a/src/plugins/props/types/map.js
+++ b/src/plugins/props/types/map.js
@@ -1,7 +1,6 @@
 import PropType from "../util/PropType.js";
+import { split } from "../util/split.js";
 import Iterable from "./iterable.js";
-
-const entrySplitter = /(?<!\\):/;
 
 /**
  * Concrete type for `Map`, which also serves as the canonical dictionary in
@@ -37,7 +36,7 @@ const MapType = PropType.register({
 		for (let item of this.parseItems(value)) {
 			let k, v;
 			if (typeof item === "string") {
-				let parts = item.split(entrySplitter);
+				let parts = [...split(item, { separator: ":" })];
 				if (parts.length >= 2) {
 					k = parts.shift();
 					v = parts.join(":");
@@ -51,9 +50,7 @@ const MapType = PropType.register({
 					v = typeof defaultValue === "function" ? defaultValue(k, index) : defaultValue;
 				}
 				k = k?.trim?.() ?? k;
-				k = k?.replaceAll?.("\\:", ":") ?? k;
 				v = v?.trim?.() ?? v;
-				v = v?.replaceAll?.("\\:", ":") ?? v;
 				if (v === "false") {
 					v = false;
 				}

--- a/src/plugins/props/types/map.js
+++ b/src/plugins/props/types/map.js
@@ -51,7 +51,9 @@ const MapType = PropType.register({
 					v = typeof defaultValue === "function" ? defaultValue(k, index) : defaultValue;
 				}
 				k = k?.trim?.() ?? k;
+				k = k?.replaceAll?.("\\:", ":") ?? k;
 				v = v?.trim?.() ?? v;
+				v = v?.replaceAll?.("\\:", ":") ?? v;
 				if (v === "false") {
 					v = false;
 				}

--- a/src/plugins/props/util/split.js
+++ b/src/plugins/props/util/split.js
@@ -15,10 +15,14 @@ function regexEscape (string) {
 	return string.replace(/[-/\\^$*+?.()|[\]{}]/g, "\\$&");
 }
 
+function unescapeSeparator (value, separator) {
+	return separator ? value.replaceAll(`\\${separator}`, separator) : value;
+}
+
 /**
  * Split a value by a separator, respecting pairs (parens, strings, etc.) but
- * failing back gracefully for malformed input. Yields each top-level part as
- * a trimmed string.
+ * failing back gracefully for malformed input. The separator can be escaped
+ * with a backslash. Yields each top-level part as a trimmed string.
  *
  * @param {string} value
  * @param {object} [options]
@@ -34,7 +38,7 @@ export function* split (value, { separator = ",", pairs = defaultPairs } = {}) {
 	let isSeparatorWhitespace = !separator;
 	let separatorRegex = isSeparatorWhitespace
 		? /\s+/g
-		: RegExp(regexEscape(separator).replace(/^\s*|\s*$/g, "\\s*"), "g");
+		: RegExp(`(?<!\\\\)${regexEscape(separator).replace(/^\s*|\s*$/g, "\\s*")}`, "g");
 
 	let pairStrings = new Set([
 		...Object.keys(pairs.nest),
@@ -46,7 +50,10 @@ export function* split (value, { separator = ",", pairs = defaultPairs } = {}) {
 
 	if (!pairRegex.test(value)) {
 		// value contains no pairs, just split
-		yield* value.trim().split(separatorRegex);
+		yield* value
+			.trim()
+			.split(separatorRegex)
+			.map(p => unescapeSeparator(p, separator));
 		return;
 	}
 
@@ -72,7 +79,7 @@ export function* split (value, { separator = ",", pairs = defaultPairs } = {}) {
 		}
 		else if (matched.trim() === separator) {
 			if (stack.length === 0) {
-				yield value.slice(lastIndex, index).trim();
+				yield unescapeSeparator(value.slice(lastIndex, index).trim(), separator);
 				lastIndex = index + matched.length;
 			}
 		}
@@ -98,6 +105,6 @@ export function* split (value, { separator = ",", pairs = defaultPairs } = {}) {
 	}
 
 	if (lastIndex < value.length) {
-		yield value.slice(lastIndex).trim();
+		yield unescapeSeparator(value.slice(lastIndex).trim(), separator);
 	}
 }

--- a/test/PropType.js
+++ b/test/PropType.js
@@ -356,6 +356,24 @@ export default {
 					},
 					expect: { 0: "a", 1: "b", 2: "c" },
 				},
+				{
+					name: "Escaped colons",
+					run (input) {
+						return PropType.for({ is: Object }).parse(input);
+					},
+					tests: [
+						{
+							name: "In values",
+							arg: "url: https\\://example.com",
+							expect: { url: "https://example.com" },
+						},
+						{
+							name: "In keys",
+							arg: "foo\\:bar: baz",
+							expect: { "foo:bar": "baz" },
+						},
+					],
+				},
 			],
 		},
 		{

--- a/test/PropType.js
+++ b/test/PropType.js
@@ -356,24 +356,6 @@ export default {
 					},
 					expect: { 0: "a", 1: "b", 2: "c" },
 				},
-				{
-					name: "Escaped colons",
-					run (input) {
-						return PropType.for({ is: Object }).parse(input);
-					},
-					tests: [
-						{
-							name: "In values",
-							arg: "url: https\\://example.com",
-							expect: { url: "https://example.com" },
-						},
-						{
-							name: "In keys",
-							arg: "foo\\:bar: baz",
-							expect: { "foo:bar": "baz" },
-						},
-					],
-				},
 			],
 		},
 		{

--- a/test/split.js
+++ b/test/split.js
@@ -50,5 +50,20 @@ export default {
 			arg: `a ", b, c`,
 			expect: [`a "`, "b", "c"],
 		},
+		{
+			name: "Escaped separator",
+			tests: [
+				{
+					name: "Default",
+					arg: "a\\, b, c",
+					expect: ["a, b", "c"],
+				},
+				{
+					name: "Custom",
+					args: ["foo\\:bar: baz", { separator: ":" }],
+					expect: ["foo:bar", "baz"],
+				},
+			],
+		},
 	],
 };


### PR DESCRIPTION
## Summary

`split()` honors `\<sep>` as an escaped separator: not split on, and the backslash is stripped from the yielded part. `MapType.parseEntries()` uses it for `:`-splitting.

## Test plan

- [x] `npx htest test/split.js --ci`
- [x] `npx htest test/PropType.js --ci`