### PR TITLE
Guard spec.parse(), event cloning, and remove applyTo()

### DIFF
--- a/src/plugins/props/util/ElementProp.js
+++ b/src/plugins/props/util/ElementProp.js
@@ -126,10 +126,22 @@ export default class ElementProp {
 			// — spec.get is effectively masked. Pre-mount writes to depless
 			// computeds are pathological config; the alternative (silently
 			// dropping the seed) seems worse.
-			let raw =
-				this.internalValue !== undefined
-					? this.internalValue
-					: spec.parse(spec.get.call(element));
+			let raw;
+			if (this.internalValue !== undefined) {
+				raw = this.internalValue;
+			}
+			else {
+				try {
+					raw = spec.parse(spec.get.call(element));
+				}
+				catch (e) {
+					console.warn(
+						`Failed to parse computed value for prop ${this.name}. Original error was:`,
+						e,
+					);
+					return;
+				}
+			}
 			return this.convert(raw);
 		}
 
@@ -150,7 +162,21 @@ export default class ElementProp {
 			raw = resolveValue(spec.default, [element, element]);
 		}
 
-		return raw === undefined ? undefined : this.convert(spec.parse(raw));
+		if (raw === undefined) {
+			return;
+		}
+
+		try {
+			raw = spec.parse(raw);
+		}
+		catch (e) {
+			console.warn(
+				`Failed to parse default value for prop ${this.name}. Original error was:`,
+				e,
+			);
+			return;
+		}
+		return this.convert(raw);
 	}
 
 	/**

--- a/src/plugins/props/util/PropChangeEvent.js
+++ b/src/plugins/props/util/PropChangeEvent.js
@@ -45,7 +45,12 @@ export default class PropChangeEvent extends Event {
 		// owns (init dict, state like `target`/`defaultPrevented`, methods).
 		for (let [key, value] of Object.entries(options)) {
 			if (!(key in Event.prototype)) {
-				this[key] = value;
+				try {
+					this[key] = value;
+				}
+				catch {
+					// [LegacyUnforgeable] own properties (e.g. isTrusted) are non-writable
+				}
 			}
 		}
 	}

--- a/src/plugins/props/util/PropChangeEvent.js
+++ b/src/plugins/props/util/PropChangeEvent.js
@@ -44,13 +44,8 @@ export default class PropChangeEvent extends Event {
 		// Assign the rest as own properties, skipping anything Event already
 		// owns (init dict, state like `target`/`defaultPrevented`, methods).
 		for (let [key, value] of Object.entries(options)) {
-			if (!(key in Event.prototype)) {
-				try {
-					this[key] = value;
-				}
-				catch {
-					// [LegacyUnforgeable] own properties (e.g. isTrusted) are non-writable
-				}
+			if (!(key in Event.prototype) && !(key in this)) {
+				this[key] = value;
 			}
 		}
 	}

--- a/src/plugins/props/util/PropChangeEvent.js
+++ b/src/plugins/props/util/PropChangeEvent.js
@@ -54,29 +54,4 @@ export default class PropChangeEvent extends Event {
 			}
 		}
 	}
-
-	/**
-	 * Replay this change on a different element. Used to mirror a prop's
-	 * value onto a sub-element from a `propchange` listener.
-	 *
-	 * Only events whose `source` is `"property"` or `"attribute"` (i.e. a user
-	 * write) are mirrored — cascade-driven changes carry `source: undefined`
-	 * and are intentionally not replicated, since the target should be reached
-	 * by its own cascade if it shares the same dep graph.
-	 *
-	 * @param {Element} target Element to apply the change to.
-	 */
-	applyTo (target) {
-		if (this.source === "attribute") {
-			if (this.attributeValue === null) {
-				target.removeAttribute(this.attributeName);
-			}
-			else {
-				target.setAttribute(this.attributeName, this.attributeValue);
-			}
-		}
-		else if (this.source) {
-			target[this.name] = this.value;
-		}
-	}
 }

--- a/src/plugins/props/util/PropChangeEvent.js
+++ b/src/plugins/props/util/PropChangeEvent.js
@@ -41,10 +41,12 @@ export default class PropChangeEvent extends Event {
 		// and silently ignores the rest.
 		super(type, options);
 
-		// Assign the rest as own properties, skipping anything Event already
-		// owns (init dict, state like `target`/`defaultPrevented`, methods).
+		// Assign the rest as own properties, skipping anything Event
+		// already owns (init dict, state, unforgeable own properties).
+		// NB: do NOT use class fields — they create own properties that
+		// would shadow options and break this check.
 		for (let [key, value] of Object.entries(options)) {
-			if (!(key in Event.prototype) && !(key in this)) {
+			if (!(key in this)) {
 				this[key] = value;
 			}
 		}


### PR DESCRIPTION
## Summary
- Wrap `spec.parse()` in `#derive()` with try/catch so invalid pre-mount values (e.g., `<color-inline>foobar</color-inline>`) degrade to `undefined` instead of throwing
- Make the `PropChangeEvent` constructor resilient to `[LegacyUnforgeable]` own properties (e.g., `isTrusted`) so `new event.constructor(event.type, { ...event })` cloning works
- Remove `applyTo()` — fundamentally broken (keys off `source`, refuses real computed-prop changes), and no longer used after `updated({change})`
- `spec.convert()` can also throw but is intentionally left unguarded (out of scope of the original PR since it also fails on `main`) — filed as #131

🤖 Generated with [Claude Code](https://claude.com/claude-code)