### PR TITLE
Guard spec.convert() against throwing

### DIFF
--- a/src/plugins/props/util/ElementProp.js
+++ b/src/plugins/props/util/ElementProp.js
@@ -307,7 +307,20 @@ export default class ElementProp {
 	 */
 	convert (value) {
 		let { convert } = this.spec;
-		return convert ? convert.call(this.element, value) : value;
+		if (!convert) {
+			return value;
+		}
+
+		try {
+			return convert.call(this.element, value);
+		}
+		catch (e) {
+			console.warn(
+				`Failed to convert value ${value} for prop ${this.name}. Original error was:`,
+				e,
+			);
+			return this.value;
+		}
 	}
 
 	/**


### PR DESCRIPTION
## Summary

- Wraps `ElementProp.convert()` in a try/catch, mirroring the existing `spec.parse()` guard pattern
- On failure, logs a `console.warn` with the value, prop name, and original error
- Falls back to the previous derived value (`this.value`), so the prop stays stable

Closes #131

## Test plan

- [x] All 56 existing prop tests pass
- [x] Manual: define a prop with a `convert` that throws on certain inputs — verify the prop retains its previous value and a warning appears in the console

🤖 Generated with [Claude Code](https://claude.com/claude-code)