### PR TITLE
Guard props hooks against missing static props

### DIFF
--- a/src/plugins/props/base.js
+++ b/src/plugins/props/base.js
@@ -30,14 +30,26 @@ const hooks = {
 	},
 
 	connected () {
+		if (!this.props) {
+			return;
+		}
+
 		this.props.paused = false;
 	},
 
 	disconnected () {
+		if (!this.props) {
+			return;
+		}
+
 		this.props.paused = true;
 	},
 
 	"attribute-changed" ({ name, oldValue }) {
+		if (!this.props) {
+			return;
+		}
+
 		this.props.attributeChanged(name, oldValue);
 	},
 };

--- a/test/plugins/props/index.js
+++ b/test/plugins/props/index.js
@@ -47,5 +47,19 @@ export default {
 		inheritance,
 		install,
 		observedAttributes,
+		{
+			name: "No static props defined",
+			description:
+				"Connect, setAttribute, disconnect cycle must not throw when a class omits static props (#134)",
+			run () {
+				let tag = defineElement({ plugins: [propsPlugin] });
+				let el = document.createElement(tag);
+
+				document.body.append(el);
+				el.setAttribute("foo", "bar");
+				el.remove();
+			},
+			throws: false,
+		},
 	],
 };


### PR DESCRIPTION
Closes #134

Props plugin hooks (`connected`, `disconnected`, `attribute-changed`) threw when no `static props` was defined because the lazy `props` getter returns `undefined` in that case.

Added early-return guards, matching the pattern used by the `styles` and `elements` plugins. Includes a regression test.